### PR TITLE
Speedup FinDate methods

### DIFF
--- a/financepy/finutils/FinDate.py
+++ b/financepy/finutils/FinDate.py
@@ -569,15 +569,14 @@ class FinDate():
         # so earliest and latest dates are 15th and 21st
 
         d_start = 15
-        d_end = 21
+        startDate = FinDate(d_start, m, y)
 
-        for d in range(d_start, d_end+1):
-            immDate = FinDate(d, m, y)
-            if immDate._weekday == self.WED:
-                return d
-
-        # Should never reach this line but just to be defensive
-        raise FinError("Third Wednesday not found")
+        if (startDate._weekday <= FinDate.WED):
+            # Wednesday is in the first week
+            return d_start + (FinDate.WED     - startDate._weekday)
+        else:
+            # Wednesday is in the second week
+            return d_start + (FinDate.WED + 7 - startDate._weekday)
 
     ##########################################################################
 

--- a/financepy/finutils/FinDate.py
+++ b/financepy/finutils/FinDate.py
@@ -394,33 +394,28 @@ class FinDate():
         you want to include regional holidays then use addBusinessDays from
         the FinCalendar class. '''
 
-        # TODO: REMOVE DATETIME DEPENDENCE HERE
-
         if isinstance(numDays, int) is False:
             raise FinError("Num days must be an integer")
 
-        dt = datetime.date(self._y, self._m, self._d)
-        d = dt.day
-        m = dt.month
-        y = dt.year
-        newDt = FinDate(d, m, y)
+        positiveNumDays = (numDays > 0)
+        numDays = abs(numDays)
+        
+        # 5 week days make up a week
+        numWeeks = int(numDays / 5)
+        remainingDays = numDays % 5
 
-        s = +1
-        if numDays < 0:
-            numDays = -1 * numDays
-            s = -1
+        if (positiveNumDays):
+            if (self._weekday + remainingDays > self.FRI):
+                # add weekend
+                remainingDays += 2
 
-        while numDays > 0:
-            dt = dt + s * datetime.timedelta(days=1)
-            d = dt.day
-            m = dt.month
-            y = dt.year
-            newDt = FinDate(d, m, y)
+            return self.addDays(numWeeks * 7 + remainingDays)
+        else:
+            if (self._weekday - remainingDays < self.MON):
+                # add weekend
+                remainingDays += 2
 
-            if newDt.isWeekend() is False:
-                numDays = numDays - 1
-
-        return newDt
+            return self.addDays(-(numWeeks * 7 + remainingDays))
 
     ###########################################################################
 

--- a/financepy/finutils/FinDate.py
+++ b/financepy/finutils/FinDate.py
@@ -686,7 +686,7 @@ class FinDate():
 
     def datetime(self):
         ''' Returns a datetime of the date '''
-        return datetime.date(self._d, self._m, self._y)
+        return datetime.date(self._y, self._m, self._d)
 
     ###########################################################################
     # TODO: Find elegant way to return long and short strings


### PR DESCRIPTION
`addDays`:
`addDays` now relies on `datetime`. The previous implementation iteratively checked whether the next date exists using `gDateCounterList`. The previous implementation takes O(n) time and requires precomputing `gDateCounterList`. The inner workings of `datetime` uses its `toordinal()` and `fromordinal()` methods to accomplish this task in O(1) time. The old implementation is still faster for me up to around 20 days added, but becomes slow as this number increases.

`addWeekDays`:
Instead of iteratively checking if each next day is a weekday, `addWeekDays` now calculates the total number of days to be added and makes use of `addDays` to do this in O(1) time.
To calculate the total number of days, I use the fact that every 5 weekdays will always take a whole week (`numWeeks = int(numDays/5)`).  All that remains is to check whether the remaining days will reach the weekend or not (if they do, add 2 more days).
This can't be used for business days because of holidays.

`thirdWednesdayOfMonth`:
Instead of iteratively checking if each day after the 15th of the month is a wednesday, `thirdWednesdayOfMonth` calculates how many days the next wednesday is from the 15th.