### PR TITLE
Fix user guide errors

### DIFF
--- a/docs/makeUserGuide.py
+++ b/docs/makeUserGuide.py
@@ -9,6 +9,7 @@ import sys
 import subprocess
 import shutil
 import fileinput
+from re import sub
 
 with open("../version.py", "r") as fh:
     version_number = fh.read()
@@ -50,6 +51,8 @@ def parseMarkdown(lines):
     for line in lines:
 
         lineFound = False
+
+        line = sub("_", "\\_", line)
 
         if line[0] == "*":
             lineFound = True


### PR DESCRIPTION
- Created an empty README.md in market/discounts. Alternatively, the line containing `buildChapter("..//financepy//market//discount")` could be commented out
- Underscores are escaped