### PR TITLE
Change Zero Bond date convention to the same as  ACT_ACT_ISDA

### DIFF
--- a/financepy/utils/day_count.py
+++ b/financepy/utils/day_count.py
@@ -187,7 +187,7 @@ class DayCount:
             acc_factor = num / den
             return acc_factor, num, den
 
-        elif self._type == DayCountTypes.ACT_ACT_ISDA:
+        elif (self._type == DayCountTypes.ACT_ACT_ISDA) or (self._type == DayCountTypes.ZERO):
 
             if is_leap_year(y1):
                 denom1 = 366
@@ -276,13 +276,6 @@ class DayCount:
             return (acc_factor, num, den)
 
         elif self._type == DayCountTypes.SIMPLE:
-
-            num = dt2 - dt1
-            den = gDaysInYear
-            acc_factor = num / den
-            return (acc_factor, num, den)
-
-        elif self._type == DayCountTypes.ZERO:
 
             num = dt2 - dt1
             den = gDaysInYear

--- a/tests/test_FinBond.py
+++ b/tests/test_FinBond.py
@@ -3,6 +3,7 @@
 ##############################################################################
 
 import sys
+
 sys.path.append("..")
 
 from financepy.utils.frequency import FrequencyTypes
@@ -61,9 +62,8 @@ def test_bondtutor_example():
 
 
 def test_bloomberg_us_treasury_example():
-
     # https://data.bloomberglp.com/bat/sites/3/2017/07/SF-2017_Paul-Fjeldsted.pdf
-    
+
     settlement_date = Date(21, 7, 2017)
     issue_date = Date(15, 5, 2010)
     maturity_date = Date(15, 5, 2027)
@@ -173,3 +173,23 @@ def test_bloomberg_apple_corp_example():
 
     conv = bond.convexity_from_ytm(settlement_date, ytm)
     assert round(conv, 4) == 0.2302
+
+
+def test_zero_bond():
+    # A 3 months treasure with 0 coupon per year.
+    bill = Bond(
+        issue_date=Date(25, 7, 2022),
+        maturity_date=Date(24, 10, 2022),
+        coupon=0,
+        freq_type=FrequencyTypes.ZERO,
+        accrual_type=DayCountTypes.ZERO
+    )
+    settlement_date = Date(8, 8, 2022)
+
+    clean_price = 99.7056
+    calc_ytm = bill.yield_to_maturity(settlement_date, clean_price, YTMCalcType.ZERO) * 100
+    assert abs(calc_ytm - 1.3998) < 0.0002
+
+
+if __name__ == '__main__':
+    test_zero_bond()


### PR DESCRIPTION
Hi, Dominic
It seems to me that it would be better to use the ACT_ACT_ISDA convention for Zero Coupon Bond, in case that the period crosses a leap year and a non-leap-year.
Do you mind if I change the DayCountTypes.ZERO algorithm in year_frac() to ACT_ACT_ISDA ?
##################
On the other hand, I am considering calculating the accrued interest of a Zero Coupon Bond. 
It's a convention in China that 
the accrued_interest of zero-coupon bond  = (principal - issue price)*(settlement_date - issue_date)/(maturity_date - issue_date)
If we adopt this convention, we need to set the issue_price of the bond.
What's your opinion?
I'll be working on it if you agree.