### PR TITLE
Remove inconsistency between df methods in DiscountCurveNS and DiscountCurveNSS 

### DIFF
--- a/financepy/market/curves/__init__.py
+++ b/financepy/market/curves/__init__.py
@@ -2,6 +2,7 @@ from .interpolator import *
 from .discount_curve import *
 from .discount_curve_flat import *
 from .discount_curve_ns import *
+from .dicount_curve_nss import *
 from .discount_curve_pwf import *
 from .discount_curve_pwl import *
 from .discount_curve_poly import *

--- a/financepy/market/curves/discount_curve_ns.py
+++ b/financepy/market/curves/discount_curve_ns.py
@@ -133,7 +133,10 @@ class DiscountCurveNS(DiscountCurve):
                               self._freq_type,
                               self._day_count_type)
 
-        return df
+        if isinstance(dates, Date):
+            return df[0]
+        else:
+            return df
 
     ###############################################################################
 


### PR DESCRIPTION
df method in DiscountCurveNS returns np.array while DiscountCurveNSS returns a scalar. 