### PR TITLE
Update bond.py to allow to define the BusDayAdjustTypes and DateGenRu…

### DIFF
--- a/financepy/products/bonds/bond.py
+++ b/financepy/products/bonds/bond.py
@@ -98,11 +98,18 @@ class Bond:
                  freq_type: FrequencyTypes,
                  accrual_type: DayCountTypes,
                  face_amount: float = 100.0,
-                 calendar_type: CalendarTypes = CalendarTypes.WEEKEND):
+                 calendar_type: CalendarTypes = CalendarTypes.WEEKEND,
+                 bus_day_rule_type: BusDayAdjustTypes =BusDayAdjustTypes.FOLLOWING,
+                 date_gen_rule_type: DateGenRuleTypes = DateGenRuleTypes.BACKWARD):
+        
         """ Create Bond object by providing the issue date, maturity Date,
         coupon frequency, annualised coupon, the accrual convention type, face
         amount and the number of ex-dividend days. A calendar type is used 
-        to determine holidays from which coupon dates might be shifted."""
+        to determine holidays from which coupon dates might be shifted.
+        BusDayAdjustTypes are used to calculate the actual payment dates. 
+        DateGenRuleTypes are used to calculate coupon dates either from backward
+        from the maturity dates or forward from the issue date.
+        """
 
         check_argument_types(self.__init__, locals())
 
@@ -145,16 +152,13 @@ class Bond:
         weekend or holiday. 
         """
 
-        # This should only be called once from init
-        bus_day_rule_type = BusDayAdjustTypes.FOLLOWING
-        date_gen_rule_type = DateGenRuleTypes.BACKWARD
 
         self._coupon_dates = Schedule(self._issue_date,
                                     self._maturity_date,
                                     self._freq_type,
                                     CalendarTypes.NONE,
-                                    bus_day_rule_type,
-                                    date_gen_rule_type)._generate()
+                                    self._bus_day_rule_type,
+                                    self._date_gen_rule_type)._generate()
 
     ###########################################################################
 


### PR DESCRIPTION
…leTypes

from financepy.utils import *
from financepy.products.bonds import *
from financepy.market.curves import *

accrual_type, frequencyType, settlementDays, exDiv, calendar = get_bond_market_conventions(BondMarkets.AZERBAIJAN) # Azerbaijan in will be in another PR

issueDt= Date(24,2,2021)
settleDt = Date(6,2,2023)
coupon = 7.5/100
maturityDt= Date(20,2,2024)

bond = Bond(issueDt, maturityDt, coupon, frequencyType, accrual_type, date_gen_rule_type=DateGenRuleTypes.FORWARD) bond.print_coupon_dates(settleDt)

 #24-AUG-2021         3.75 
 #24-FEB-2022         3.75 
 #24-AUG-2022         3.75 
 #24-FEB-2023         3.75 
 #24-AUG-2023         3.75 
 #20-FEB-2024       103.75 

#The last coupon amount is wrong, but it is another issue.