### PR TITLE
Cash flows on coupon payment days

### DIFF
--- a/financepy/products/bonds/bond.py
+++ b/financepy/products/bonds/bond.py
@@ -418,8 +418,8 @@ class Bond:
 
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on the settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on a settlement date are paid to the seller
+            if dt > settlement_date:
                 df = discount_curve.df(dt)
                 flow = self._coupon / self._frequency
                 pv = flow * df
@@ -500,8 +500,8 @@ class Bond:
             raise FinError("Accrued interest - not enough flow dates.")
 
         for iFlow in range(1, num_flows):
-            # coupons paid on a settlement date are paid
-            if self._coupon_dates[iFlow] >= settlement_date:
+            # coupons paid on a settlement date are paid to the seller
+            if self._coupon_dates[iFlow] > settlement_date:
                 self._pcd = self._coupon_dates[iFlow - 1]
                 self._ncd = self._coupon_dates[iFlow]
                 break
@@ -550,8 +550,8 @@ class Bond:
 
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on a settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on a settlement date are paid to the seller
+            if dt > settlement_date:
                 df = discount_curve.df(dt)
                 pvIbor += df * self._coupon / self._frequency
 
@@ -596,8 +596,8 @@ class Bond:
         pv = 0.0
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on a settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on a settlement date are paid to the seller
+            if dt > settlement_date:
                 t = (dt - settlement_date) / gDaysInYear
 
                 t = np.maximum(t, gSmall)
@@ -667,8 +667,8 @@ class Bond:
         flow_str = ""
 
         for dt in self._coupon_dates[1:-1]:
-            # coupons paid on a settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on a settlement date are paid to the seller
+            if dt > settlement_date:
                 flow_str += ("%12s %12.2f \n" % (dt, flow))
 
         redemption_amount = self._face_amount + flow
@@ -713,8 +713,8 @@ class Bond:
 
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on a settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on a settlement date are paid to the seller
+            if dt > settlement_date:
                 df = discount_curve.df(dt)
                 q = survival_curve.survival_prob(dt)
 

--- a/financepy/products/bonds/bond_zero.py
+++ b/financepy/products/bonds/bond_zero.py
@@ -258,8 +258,8 @@ class BondZero:
 
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on the settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on the settlement date are paid to the seller
+            if dt > settlement_date:
                 df = discount_curve.df(dt)
                 flow = 0
                 pv = flow * df
@@ -348,8 +348,8 @@ class BondZero:
             raise FinError("Accrued interest - not enough flow dates.")
 
         for iFlow in range(1, num_flows):
-            # coupons paid on a settlement date are paid
-            if self._coupon_dates[iFlow] >= settlement_date:
+            # coupons paid on the settlement date are paid to the seller
+            if self._coupon_dates[iFlow] > settlement_date:
                 self._pcd = self._coupon_dates[iFlow - 1]
                 self._ncd = self._coupon_dates[iFlow]
                 break
@@ -401,8 +401,8 @@ class BondZero:
 
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on a settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on the settlement date are paid to the seller
+            if dt > settlement_date:
                 df = discount_curve.df(dt)
                 # pvIbor += df * self._coupon / self._frequency
 
@@ -445,8 +445,8 @@ class BondZero:
         pv = 0.0
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on a settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on the settlement date are paid to the seller
+            if dt > settlement_date:
                 t = (dt - settlement_date) / gDaysInYear
 
                 t = np.maximum(t, gSmall)
@@ -548,8 +548,8 @@ class BondZero:
 
         for dt in self._coupon_dates[1:]:
 
-            # coupons paid on a settlement date are included
-            if dt >= settlement_date:
+            # coupons paid on the settlement date are paid to the seller
+            if dt > settlement_date:
                 df = discount_curve.df(dt)
                 q = survival_curve.survival_prob(dt)
 


### PR DESCRIPTION
As issue #155 suggested, coupons paid on the settlement date are paid to the seller. The buyer does NOT get the coupon.
I deleted the equal signs in bond.py and bond_zero.py where 
``` python
if dt >= settlement_date:
```
