### PR TITLE
Added Bond class attributes bus_day_rule_type and date_gen_rule_type

### DIFF
--- a/financepy/products/bonds/bond.py
+++ b/financepy/products/bonds/bond.py
@@ -98,7 +98,9 @@ class Bond:
                  freq_type: FrequencyTypes,
                  accrual_type: DayCountTypes,
                  face_amount: float = 100.0,
-                 calendar_type: CalendarTypes = CalendarTypes.WEEKEND):
+                 calendar_type: CalendarTypes = CalendarTypes.WEEKEND,
+                 bus_day_rule_type = BusDayAdjustTypes.FOLLOWING,
+                 date_gen_rule_type = DateGenRuleTypes.BACKWARD):
         """ Create Bond object by providing the issue date, maturity Date,
         coupon frequency, annualised coupon, the accrual convention type, face
         amount and the number of ex-dividend days. A calendar type is used 
@@ -140,6 +142,9 @@ class Bond:
         self._accrued_days = 0.0
         self._alpha = 0.0
 
+        self.bus_day_rule_type = bus_day_rule_type
+        self.date_gen_rule_type = date_gen_rule_type
+
         self._calculate_coupon_dates()
         self._calculate_flows()
 
@@ -152,15 +157,15 @@ class Bond:
         """
 
         # This should only be called once from init
-        bus_day_rule_type = BusDayAdjustTypes.FOLLOWING
-        date_gen_rule_type = DateGenRuleTypes.BACKWARD
+        #bus_day_rule_type = BusDayAdjustTypes.FOLLOWING
+        #date_gen_rule_type = DateGenRuleTypes.BACKWARD
 
         self._coupon_dates = Schedule(self._issue_date,
                                     self._maturity_date,
                                     self._freq_type,
                                     CalendarTypes.NONE,
-                                    bus_day_rule_type,
-                                    date_gen_rule_type, 
+                                    self.bus_day_rule_type,
+                                    self.date_gen_rule_type, 
                                     end_of_month = self._end_of_month)._generate()
 
     ###########################################################################

--- a/financepy/products/inflation/FinInflationBond.py
+++ b/financepy/products/inflation/FinInflationBond.py
@@ -39,8 +39,10 @@ class FinInflationBond(Bond):
         the base CPI used for all coupon and principal related calculations. 
         The class inherits from Bond so has many similar functions. The YTM"""
 
+        Bond.__init__(self,issue_date, maturity_date, coupon, freq_type, accrual_type, face_amount, calendar_type)
         check_argument_types(self.__init__, locals())
 
+        
         if issue_date >= maturity_date:
             raise FinError("Issue Date must preceded maturity date.")
 

--- a/financepy/utils/helpers.py
+++ b/financepy/utils/helpers.py
@@ -475,8 +475,9 @@ def check_argument_types(func, values):
     will not be checked. """
     for valueName, annotationType in func.__annotations__.items():
 
-        value = values[valueName]
-        usableType = to_usable_type(annotationType)
+        if valueName in values:
+            value = values[valueName]
+            usableType = to_usable_type(annotationType)
         
         if (not isinstance(value, usableType)):
 


### PR DESCRIPTION
In Bond class' _calculate_coupon_dates method @domokane  had the following note:
      ` # This should only be called once from init`
       ` bus_day_rule_type = BusDayAdjustTypes.FOLLOWING`
        `date_gen_rule_type = DateGenRuleTypes.BACKWARD`

So I have made this change. But I had to change FinInflationBond class too because this is the only class that inherits from the Bond class, as far as I have seen.

I had to change the check_argument_types helper function. Because it was giving key error about `base_cpi_value` locals() were combined because I called Bond.__init__() inside FinInflationBond class.

Now that I have called Bond.__init__() some redundant attribute definitions can be removed from FinInflationBond class. I have not removed them.