### PR TITLE
Finite difference method

### DIFF
--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -13,9 +13,9 @@ class PUT_CALL(Enum):
     CALL = 1
 
 
-class AMER_EURO(Enum):
-    EURO = 0
-    AMER = 1
+class exercise_type(Enum):
+    EUROPEAN = 1
+    AMERICAN = 2
 
 
 def dx(x, wind=0):
@@ -253,7 +253,7 @@ def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expi
     var_ = (s * sigma) ** 2
 
     # Store original res if option is American
-    if exercise == AMER_EURO.AMER.value:
+    if exercise == exercise_type.AMERICAN.value:
         res0 = copy(res)
 
     # repeat
@@ -271,7 +271,7 @@ def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expi
                     Ai = calculate_fd_matrix(s, r_, mu_, var_, -dt, theta, wind)
 
             res = fd_roll_backwards(res, theta, Ai=Ai, Ae=Ae)
-            if exercise == AMER_EURO.AMER.value:
+            if exercise == exercise_type.AMERICAN.value:
                 idx = res[0] < res0[0]
                 res[0][idx] = res0[0][idx]
 

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -1,0 +1,251 @@
+from enum import Enum
+from copy import copy
+
+import numpy as np
+
+from ..utils.math import band_matrix_multiplication, solve_tridiagonal_matrix, transpose_tridiagonal_matrix, sign
+
+class PUT_CALL(Enum):
+    PUT = -1
+    CALL = 1
+
+class AMER_EURO(Enum):
+    EURO = 0
+    AMER = 1
+
+def dx(x, wind=0):
+    n = len(x) - 1
+    out = np.zeros((n + 1, 3))
+
+    dxu = x[1] - x[0]
+
+    # First row
+    if wind >= 0:
+        out[0] = (-1, 0, 1)
+        out[0] /= dxu
+
+    # Intermediate rows
+    for i in range(1, n):
+        dxl = x[i] - x[i - 1]
+        dxu = x[i + 1] - x[i]
+        if wind < 0:
+            out[i] = (-1, 1, 0)
+            out[i] /= dxl
+        elif wind == 0:
+            out[i] = (- dxu / dxl,
+                      dxu / dxl - dxl / dxu,
+                      dxl / dxu)
+            out[i] /= (dxl + dxu)
+        else:
+            out[i] = (0, -1, 1)
+            out[i] /= dxu
+
+    # Last row
+    if wind <= 0:
+        dxl = x[n] - x[n - 1]
+        out[n] = (-1, 1, 0)
+        out[n] /= dxl
+    else:
+        out[n] = (0, 0, 0)
+
+    return out
+
+
+def dxx(x):
+    n = len(x) - 1
+    out = np.zeros((n + 1, 3))
+
+    # First row
+    out[0] = (0, 0, 0)
+
+    # Intermediate rows
+    for i in range(1, n):
+        dxl = x[i] - x[i - 1]
+        dxu = x[i + 1] - x[i]
+
+        out[i] = (1 / dxl,
+                  -(1 / dxl + 1 / dxu),
+                  1 / dxu
+                  )
+        out[i] *= 2.0 / (dxl + dxu)
+
+    # Last row
+    out[n] = (0, 0, 0)
+
+    return out
+
+
+def calculate_fd_matrix(x, r, mu, var, dt, theta, wind=0):
+    """
+    1d finite difference solution for pdes of the form
+
+    0 = dV/dt + A V
+
+    A = -r + mu d/dx + 1/2 var d^2/dx^2
+
+    using the theta scheme
+
+    [1-theta dt A] V(t) = [1 + (1-theta) dt A] V(t+dt)
+    """
+    if dt == 0:
+        raise ValueError("Timestep length dt must be non-zero")
+    if theta == 0:
+        raise ValueError("Theta must be non-zero")
+
+    Dxd = dx(x, -1)
+    Dxu = dx(x, 1)
+    Dxx = dxx(x)
+    Dx = dx(x, 0)
+
+    if wind < 0:
+        Dx = Dxd
+    elif wind == 1:
+        Dx = Dxu
+
+    n = len(x)
+    m = Dx.shape[1]
+    A = np.zeros((n, m))
+
+    mm = m // 2  # integer division
+    dtTheta = dt * theta
+    for i in range(n):
+        if wind > 1:
+            Dx = Dxd if mu[i] < 0 else Dxu
+
+        for j in range(m):
+            A[i, j] = dtTheta * (mu[i] * Dx[i, j] + 0.5 * var[i] * Dxx[i, j])
+
+        A[i, mm] += 1 - dtTheta * r[i]
+
+    return A
+
+
+def fd_roll_backwards(x, r, mu, var, dt, res, theta, update, Ai=np.array([]), Ae=np.array([]), wind=0):
+    num_vectors = len(res)
+    mm = 1
+
+    # Explicit case
+    if theta != 1:
+        if update:
+            Ai = calculate_fd_matrix(x, r, mu, var, dt, 1 - theta, wind)
+        for k in range(num_vectors):
+            res[k] = band_matrix_multiplication(Ai, mm, mm, res[k])
+
+    # Implicit case
+    if theta != 0:
+        if update:
+            Ae = calculate_fd_matrix(x, r, mu, var, -dt, theta, wind)
+        for k in range(num_vectors):
+            res[k] = solve_tridiagonal_matrix(Ae, res[k])
+
+    return res, Ai, Ae
+
+
+def fd_roll_forwards(x, r, mu, var, dt, res, theta, update, Ai=np.array([]), Ae=np.array([]), wind=0):
+    num_vectors = len(res)
+    mm = num_vectors // 2  # integer division
+
+    # Implicit case
+    if theta != 0:
+        if update:
+            Ai = calculate_fd_matrix(x, r, mu, var, -dt, theta, wind)
+            Ai = transpose_tridiagonal_matrix(Ai)
+        for k in range(num_vectors):
+            res[k] = solve_tridiagonal_matrix(Ai, res[k])
+
+    # Explicit case
+    if theta != 1:
+        if update:
+            Ae = calculate_fd_matrix(x, r, mu, var, dt, 1 - theta, wind)
+            Ae = transpose_tridiagonal_matrix(Ae)
+        for k in range(num_vectors):
+            res[k] = band_matrix_multiplication(Ae, mm, mm, res[k])
+
+    return res, Ai, Ae
+
+
+def smooth_digital(xl, xu, strike):
+    if xu <= strike:
+        res = 0
+    elif strike <= xl:
+        res = 1
+    else:
+        res = (xu - strike) / (xu - xl)
+
+    return res
+
+
+def smooth_call(xl, xu, strike):
+    if xu <= strike:
+        res = 0
+    elif strike <= xl:
+        res = 0.5 * (xl + xu) - strike
+    else:
+        res = 0.5 * (xu - strike) ** 2 / (xu - xl)
+
+    return res
+
+
+def black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                    num_std, num_t, num_s, update, num_pr):
+    t = max(0, expiry)
+    std = sigma * (t ** 0.5)
+    xl = -num_std * std
+    xu = num_std * std
+    d_x = (xu - xl) / max(1, num_s)
+    nums = num_s
+    if nums <= 0 or xl == xu:
+        nums = 1
+    else:
+        nums += 1
+
+    # Create sample set s
+    s = np.zeros(nums)
+    s[0] = s0 * np.exp(xl)
+    ds = np.exp(d_x)
+
+    for i in range(1, nums):
+        s[i] = s[i - 1] * ds
+    res = np.zeros(nums)
+    for i in range(nums):
+        if smooth == 0 or i == 0 or i == nums - 1:
+            if dig:
+                res[i] = 0.5 * (sign(s[i] - strike) + 1)
+            else:
+                res[i] = max(0, s[i] - strike)
+        else:
+            sl = 0.5 * (s[i - 1] + s[i]);
+            su = 0.5 * (s[i] + s[i + 1]);
+            if dig:
+                res[i] = smooth_digital(sl, su, strike)
+            else:
+                res[i] = smooth_call(sl, su, strike)
+
+        if pc == PUT_CALL.PUT.value:
+            if dig:
+                res[i] = 1 - res[i]
+            else:
+                res[i] -= (s[i] - strike)
+
+    # time steps
+    numt = max(0, num_t)
+    dt = t / max(1, numt)
+
+    # repeat
+    res = np.array([res])
+    res0 = copy(res)
+    nump = max(1, num_pr)
+    for p in range(nump):
+        r_ = np.zeros(nums) + r
+        mu_ = mu * s
+        var_ = (s * sigma) ** 2
+        Ai = np.array([])
+        Ae = np.array([])
+        for h in range(numt):
+            res, Ai, Ae = fd_roll_backwards(
+                s, r_, mu_, var_, dt, res, theta, update=update or h == 0, Ai=Ai, Ae=Ae, wind=wind)
+            if ea == AMER_EURO.AMER.value:
+                for i in range(nums):
+                    res[0][i] = max(res[0][i], res0[0][i])
+
+    return res[0], res[0][nums // 2]

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import numpy as np
 
-from ..utils.math import band_matrix_multiplication, solve_tridiagonal_matrix, transpose_tridiagonal_matrix, sign
+from ..utils.math import band_matrix_multiplication, solve_tridiagonal_matrix, transpose_tridiagonal_matrix
 
 class PUT_CALL(Enum):
     PUT = -1
@@ -167,7 +167,7 @@ def smooth_digital(xl, xu, strike):
 
 
 def digital(x, strike):
-    return 0.5 * (sign(x - strike) + 1)
+    return 0.5 * (np.sign(x - strike) + 1)
 
 
 def smooth_call(xl, xu, strike):

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -177,7 +177,7 @@ def smooth_call(xl, xu, strike):
         return 0.5 * (xu - strike) ** 2 / (xu - xl)
 
 
-def initial_curve(s, strike, smooth, dig, option_type):
+def option_payoff(s, strike, smooth, dig, option_type):
     num_samples = len(s)
 
     # Generate middle values (i.e. not first or last, which are overwritten later)
@@ -240,8 +240,8 @@ def black_scholes_finite_difference(stock_price, sigma, expiry_date, valuation_d
     # Create sample set s
     s = stock_price * np.exp(xl + d_x * np.arange(0, num_samples))
 
-    # Define the initial curve which will be fitted with each iteration
-    res = initial_curve(s, strike_price, smooth, digital, option_type)
+    # Generate the option payoff to be fitted
+    res = option_payoff(s, strike_price, smooth, digital, option_type)
 
     # time steps
     dt = time_to_expiry / max(1, num_steps)

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -122,8 +122,7 @@ def calculate_fd_matrix(x, r, mu, var, dt, theta, wind=0):
         if wind > 1:
             Dx = Dxd if mu[i] < 0 else Dxu
 
-        for j in range(m):
-            A[i, j] = dtTheta * (mu[i] * Dx[i, j] + 0.5 * var[i] * Dxx[i, j])
+        A[i] = dtTheta * (mu[i] * Dx[i] + 0.5 * var[i] * Dxx[i])
 
         A[i, mm] += 1 - dtTheta * r[i]
 

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -229,7 +229,7 @@ def initial_curve(s, strike, smooth, dig, option_type):
 
 def black_scholes_finite_difference(stock_price, sigma, expiry_date, valuation_date,
                                     strike_price, discount_curve, dividend_curve, digital, option_type, smooth, theta,
-                                    wind, num_std, num_steps, num_samples, update, num_pr):
+                                    wind, num_std, num_steps, num_samples, update):
     # Time to contract expiry in years
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
 
@@ -272,9 +272,6 @@ def black_scholes_finite_difference(stock_price, sigma, expiry_date, valuation_d
 
     # Store original res as res0
     res0 = deepcopy(res)
-
-    # repeat
-    nump = max(1, num_pr)
 
     Ai = np.array([])
     Ae = np.array([])

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -9,16 +9,6 @@ from ..utils.global_vars import gDaysInYear
 from financepy.utils.global_types import OptionTypes
 
 
-class PUT_CALL(Enum):
-    PUT = -1
-    CALL = 1
-
-
-class exercise_type(Enum):
-    EUROPEAN = 1
-    AMERICAN = 2
-
-
 def dx(x, wind=0):
     n = len(x) - 1
     out = np.zeros((n + 1, 3))

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -60,15 +60,15 @@ def dxx(x):
     out[0] = (0, 0, 0)
 
     # Intermediate rows
-    for i in range(1, n):
-        dxl = x[i] - x[i - 1]
-        dxu = x[i + 1] - x[i]
-
-        out[i] = (1 / dxl,
-                  -(1 / dxl + 1 / dxu),
-                  1 / dxu
-                  )
-        out[i] *= 2.0 / (dxl + dxu)
+    # Note: As first and last rows are handled separately,
+    # we can use numpy roll without worrying about the end values
+    dxl = (x - np.roll(x, 1))[1:-1]
+    dxu = (np.roll(x, -1) - x)[1:-1]
+    out[1:-1] = np.array([1 / dxl,
+              -(1 / dxl + 1 / dxu),
+              1 / dxu]
+              ).T
+    out[1: -1] *= 2.0 / np.atleast_2d(dxl + dxu).T
 
     # Last row
     out[n] = (0, 0, 0)

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -120,7 +120,7 @@ def calculate_fd_matrix(x, r, mu, var, dt, theta, wind=0):
     return A
 
 
-def fd_roll_backwards(res, theta, Ai=np.array([]), Ae=np.array([]), wind=0):
+def fd_roll_backwards(res, theta, Ai=np.array([]), Ae=np.array([])):
     num_vectors = len(res)
     mm = 1
 
@@ -137,27 +137,23 @@ def fd_roll_backwards(res, theta, Ai=np.array([]), Ae=np.array([]), wind=0):
     return res
 
 
-def fd_roll_forwards(x, r, mu, var, dt, res, theta, update, Ai=np.array([]), Ae=np.array([]), wind=0):
+def fd_roll_forwards(res, theta, Ai=np.array([]), Ae=np.array([])):
     num_vectors = len(res)
     mm = num_vectors // 2  # integer division
 
     # Implicit case
     if theta != 0:
-        if update:
-            Ai = calculate_fd_matrix(x, r, mu, var, -dt, theta, wind)
-            Ai = transpose_tridiagonal_matrix(Ai)
+        Ai = transpose_tridiagonal_matrix(Ai)
         for k in range(num_vectors):
             res[k] = solve_tridiagonal_matrix(Ai, res[k])
 
     # Explicit case
     if theta != 1:
-        if update:
-            Ae = calculate_fd_matrix(x, r, mu, var, dt, 1 - theta, wind)
-            Ae = transpose_tridiagonal_matrix(Ae)
+        Ae = transpose_tridiagonal_matrix(Ae)
         for k in range(num_vectors):
             res[k] = band_matrix_multiplication(Ae, mm, mm, res[k])
 
-    return res, Ai, Ae
+    return res
 
 
 def smooth_digital(xl, xu, strike):
@@ -246,7 +242,7 @@ def black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, e
                 if theta != 0:
                     Ai = calculate_fd_matrix(s, r_, mu_, var_, -dt, theta, wind)
 
-            res = fd_roll_backwards(res, theta, Ai=Ai, Ae=Ae, wind=wind)
+            res = fd_roll_backwards(res, theta, Ai=Ai, Ae=Ae)
             if ea == AMER_EURO.AMER.value:
                 for i in range(nums):
                     res[0][i] = max(res[0][i], res0[0][i])

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -223,12 +223,10 @@ def initial_curve(s, strike, smooth, dig, pc):
     return np.atleast_2d(res)
 
 
-def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expiry_date, valuation_date, strike_price, dig, pc, exercise,
-                                    smooth, theta, wind, num_std, num_steps, num_samples, update, num_pr):
-    # TODO Get expiry from expiry and valuation date
-    expiry = (expiry_date - valuation_date) / gDaysInYear
-    t = max(0, expiry)
-    std = sigma * (t ** 0.5)
+def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expiry_date, valuation_date, strike_price,
+                                    dig, pc, exercise, smooth, theta, wind, num_std, num_steps, num_samples, update, num_pr):
+    time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
+    std = sigma * (time_to_expiry ** 0.5)
     xl = -num_std * std
     xu = num_std * std
     d_x = (xu - xl) / max(1, num_samples)
@@ -245,7 +243,7 @@ def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expi
     res = initial_curve(s, strike_price, smooth, dig, pc)
 
     # time steps
-    dt = t / max(1, num_steps)
+    dt = time_to_expiry / max(1, num_steps)
 
     # Make time series
     r_ = np.zeros(num_samples) + risk_free_rate

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -64,11 +64,12 @@ def dxx(x):
     # we can use numpy roll without worrying about the end values
     dxl = (x - np.roll(x, 1))[1:-1]
     dxu = (np.roll(x, -1) - x)[1:-1]
-    out[1:-1] = np.array([1 / dxl,
-              -(1 / dxl + 1 / dxu),
-              1 / dxu]
-              ).T
-    out[1: -1] *= 2.0 / np.atleast_2d(dxl + dxu).T
+    intermediate_rows = np.array(
+        [2 / dxl,
+        -(2 / dxl + 2 / dxu),
+        2 / dxu]
+    ) / (dxu + dxl)
+    out[1:-1] = intermediate_rows.T
 
     # Last row
     out[n] = (0, 0, 0)

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -225,9 +225,11 @@ def initial_curve(s, strike, smooth, dig, pc):
     return np.atleast_2d(res)
 
 
-def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expiry_date, valuation_date, strike_price,
-                                    dig, pc, exercise, smooth, theta, wind, num_std, num_steps, num_samples, update, num_pr):
+def black_scholes_finite_difference(stock_price, risk_free_rate, dividend_yield, sigma, expiry_date, valuation_date,
+                                    strike_price, digital, pc, exercise, smooth, theta, wind, num_std, num_steps,
+                                    num_samples, update, num_pr):
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
+    mu = risk_free_rate - dividend_yield
     std = sigma * (time_to_expiry ** 0.5)
     xl = -num_std * std
     xu = num_std * std
@@ -242,7 +244,7 @@ def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expi
         s[i] = s[i - 1] * ds
 
     # Define the initial curve which will be fitted with each iteration
-    res = initial_curve(s, strike_price, smooth, dig, pc)
+    res = initial_curve(s, strike_price, smooth, digital, pc)
 
     # time steps
     dt = time_to_expiry / max(1, num_steps)

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -222,8 +222,10 @@ def initial_curve(s, strike, smooth, dig, pc):
     return np.atleast_2d(res)
 
 
-def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expiry, strike_price, dig, pc, exercise, smooth, theta, wind,
-                                    num_std, num_steps, num_samples, update, num_pr):
+def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expiry, strike_price, dig, pc, exercise,
+                                    smooth, theta, wind, num_std, num_steps, num_samples, update, num_pr):
+    # TODO Get expiry from expiry and valuation date
+    # expiry = (expiry_date - valuation_date) / gDaysInYear
     t = max(0, expiry)
     std = sigma * (t ** 0.5)
     xl = -num_std * std

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -5,6 +5,7 @@ from functools import partial
 import numpy as np
 
 from ..utils.math import band_matrix_multiplication, solve_tridiagonal_matrix, transpose_tridiagonal_matrix
+from ..utils.global_vars import gDaysInYear
 
 
 class PUT_CALL(Enum):
@@ -222,10 +223,10 @@ def initial_curve(s, strike, smooth, dig, pc):
     return np.atleast_2d(res)
 
 
-def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expiry, strike_price, dig, pc, exercise,
+def black_scholes_finite_difference(stock_price, risk_free_rate, mu, sigma, expiry_date, valuation_date, strike_price, dig, pc, exercise,
                                     smooth, theta, wind, num_std, num_steps, num_samples, update, num_pr):
     # TODO Get expiry from expiry and valuation date
-    # expiry = (expiry_date - valuation_date) / gDaysInYear
+    expiry = (expiry_date - valuation_date) / gDaysInYear
     t = max(0, expiry)
     std = sigma * (t ** 0.5)
     xl = -num_std * std

--- a/financepy/utils/math.py
+++ b/financepy/utils/math.py
@@ -667,19 +667,19 @@ def npv(irr: float, times_cfs: list):
 
 
 def band_matrix_multiplication(A, m1, m2, b):
-    n = A.shape[0] - 1
-    x = np.zeros(n + 1)
+    n = A.shape[0]
+    x = np.zeros(n)
 
-    for i in range(n + 1):
-        jl = max(0, i - m1)
-        ju = min(i + m2, n)
-        xi = 0
+    jl = np.arange(n) - m1
+    jl[jl < 0] = 0
 
-        for j in range(jl, ju + 1):
-            k = j - i + m1
-            xi += A[i, k] * b[j]
+    ju = np.arange(n) + m2
+    ju[ju > n - 1] = n - 1
 
-        x[i] = xi
+    for i in range(n):
+        j = np.arange(jl[i], ju[i] + 1)
+        k = j - i + m1
+        x[i] += np.sum(A[i, k] * b[j])
 
     return x
 

--- a/financepy/utils/math.py
+++ b/financepy/utils/math.py
@@ -727,12 +727,3 @@ def transpose_tridiagonal_matrix(A):
     out = np.zeros_like(A)
     out[:, 0], out[:, 1], out[:, 2] = A[:, 2], A[:, 1], A[:, 0]
     return out
-
-
-def sign(x):
-    if x < 0:
-        return -1
-    elif x > 0:
-        return 1
-    else:
-        return 0

--- a/financepy/utils/math.py
+++ b/financepy/utils/math.py
@@ -684,6 +684,7 @@ def band_matrix_multiplication(A, m1, m2, b):
     return x
 
 
+@njit(fastmath=True, cache=True)
 def solve_tridiagonal_matrix(A, r):
     """
     Solve A u = r for vector u when A is tridiagonal
@@ -723,6 +724,7 @@ def solve_tridiagonal_matrix(A, r):
     return u
 
 
+@njit(fastmath=True, cache=True)
 def transpose_tridiagonal_matrix(A):
     out = np.zeros_like(A)
     out[:, 0], out[:, 1], out[:, 2] = A[:, 2], A[:, 1], A[:, 0]

--- a/notebooks/models/FINITE_DIFFERENCE.ipynb
+++ b/notebooks/models/FINITE_DIFFERENCE.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f8e495bf",
+   "metadata": {},
+   "source": [
+    "# Finite Difference Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54906ae9",
+   "metadata": {},
+   "source": [
+    "Use Finite Difference method to value an option.\n",
+    "\n",
+    "The underlying code used is based on the fd_runner method [here](https://github.com/domokane/CompFin/blob/main/Week%204/xladdin/Utility/kBlack.cpp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "97541141",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "####################################################################\n",
+      "# FINANCEPY BETA Version 0.270 - This build:  26 Feb 2023 at 19:12 #\n",
+      "#      This software is distributed FREE & WITHOUT ANY WARRANTY    #\n",
+      "#  Report bugs as issues at https://github.com/domokane/FinancePy  #\n",
+      "####################################################################\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from copy import copy\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from financepy.models.finite_difference import (\n",
+    "    dx, dxx, fd_roll_backwards, fd_roll_forwards, black_scholes_finite_difference)\n",
+    "from financepy.utils.math import band_matrix_multiplication, solve_tridiagonal_matrix\n",
+    "from financepy.utils.date import Date\n",
+    "from financepy.utils.global_types import OptionTypes\n",
+    "from financepy.products.equity.equity_vanilla_option import EquityVanillaOption\n",
+    "from financepy.market.curves.discount_curve_flat import DiscountCurveFlat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e3b3231a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expiry_date = Date(1, 7, 2015)\n",
+    "strike_price = 100.0\n",
+    "option_type = OptionTypes.EUROPEAN_CALL\n",
+    "call_option = EquityVanillaOption(\n",
+    "    expiry_date, strike_price, option_type)\n",
+    "\n",
+    "valuation_date = Date(1, 1, 2015)\n",
+    "stock_price = 100\n",
+    "volatility = 0.30\n",
+    "interest_rate = 0.05\n",
+    "dividend_yield = 0.01\n",
+    "discount_curve = DiscountCurveFlat(valuation_date, interest_rate)\n",
+    "dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)\n",
+    "\n",
+    "num_std = 5\n",
+    "num_samples = 200\n",
+    "num_steps = 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aa1c317e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,\n",
+    "                                         expiry_date=expiry_date, valuation_date=valuation_date,\n",
+    "                                         strike_price=100.0, discount_curve=discount_curve,\n",
+    "                                         dividend_curve=dividend_curve, digital=0,\n",
+    "                                         option_type=option_type, smooth=0, theta=0.5, wind=0,\n",
+    "                                         num_std=num_std, num_steps=num_steps, num_samples=num_samples,\n",
+    "                                         update=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f38c2c20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create samples (this is done in black_scholes_finite_difference\n",
+    "# but we do it here for plotting)\n",
+    "time_to_expiry = (expiry_date - valuation_date) / 365\n",
+    "std = volatility * (time_to_expiry ** 0.5)\n",
+    "xl = -num_std * std\n",
+    "xu = num_std * std\n",
+    "d_x = (xu - xl) / max(1, num_samples)\n",
+    "num_samples = 1 if num_samples <= 0 or xl == xu else num_samples + 1\n",
+    "s = np.zeros(num_samples)\n",
+    "s[0] = stock_price * np.exp(xl)\n",
+    "ds = np.exp(d_x)\n",
+    "for i in range(1, num_samples):\n",
+    "    s[i] = s[i - 1] * ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fef7463a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAGwCAYAAABPSaTdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABQZklEQVR4nO3deVxU5f4H8M/MMAyLLAIioKhoKi6AsmZ5TXNFr2Xa4pYopmnaoq22qrff1Vvd6to1LROXrmZaamWloblUooCKuJIgisqigDDAyDDL8/uDnCRAFmHOzPB5v168ZM555pzvzBeGj3POeUYmhBAgIiIislFyqQsgIiIiak4MO0RERGTTGHaIiIjIpjHsEBERkU1j2CEiIiKbxrBDRERENo1hh4iIiGyandQFWAKj0Yjs7Gy4uLhAJpNJXQ4RERHVgxACJSUl8PPzg1xe+/s3DDsAsrOz4e/vL3UZRERE1AiXLl1C+/bta13PsAPAxcUFQOWT5erqarb96nQ6/PTTTxg2bBiUSqXZ9ktVsQ+WgX2wDOyDZWAf6ketVsPf39/0d7w2DDuA6dCVq6ur2cOOk5MTXF1d+cMsIfbBMrAPloF9sAzsQ8PUdQoKT1AmIiIim8awQ0RERDaNYYeIiIhsGsMOERER2TSGHSIiIrJpDDtERERk0xh2iIiIyKYx7BAREZFNY9ghIiIim8awQ0RERDaNYYeIiIhsGsMOERER2TSGHSIiIrJKv5y7Vq9xDDtERERkdVYdOI/Z/ztar7F2zVwLERERUZMxGgWW7jyLTw+cr/d9+M4OERERWQWdwYjntxw3BZ15Q7vW634MO0RERGTxyrR6TF+XjG3HrkAhl+Hfj4Rgev/O9bovD2MRERGRRSso1SJ2bRKOXy6Go1KBjyeFYlCgN9Rqdb3uz7BDREREFutSoQZT4hKRmV+G1k5KxE2NQN8OrRu0DYYdIiIiskins9WIWZOIayVatHN3xPrpkejSplWDt8OwQ0RERBYnIaMAM9cno0SrR/e2LlgXGwkfN4dGbYthh4iIiCzKDydy8NymFFQYjIgM8MCqKeFwc1Q2ensMO0RERGQxPk+4gDe/PQUhgOG92uI/4/vCQam4o20y7BAREZHkhBB4P/53fPRzOgBgYlQH/OPB3lDIZXe8bYYdIiIikpTeYMTr209iU9IlAMBzQ7ri2cFdIZPdedABGHaIiIhIQuU6A+ZuPIbdZ/IglwH/GNMbk6I6Nuk+GHaIiIhIEkWaCjyxLhnJF6/D3k6OZeP7YkRvnybfD8MOERERmV1O8Q1MWZ2Ic1dL4eJgh8+mhCOqs2ez7Ithh4iIiMwq/WoJpqxORHZxOdq6qrAuNhKBPq7Ntj+GHSIiIjKbIxcLEbs2GcU3dOjcxhnrYyPRvrVTs+6TYYeIiIjMYvfpPMz94ijKdUb08XdH3NQIeDjbN/t+GXaIiIio2W1OvoQFW0/AYBQY1L0Nlk8KhZO9eWIIww4RERE1GyEEPt6XgXd3pQEAxoW2x9JxQVAq5GargWGHiIiImoXRKLB4x2msPXgBADB7YBe8NLx7k00WWF8MO0RERNTktHoD5m8+ju9TcwAAb/y9J6b3D5CkFvO9h1SDAwcOYPTo0fDz84NMJsP27durrJfJZDV+vfvuu6YxnTp1qrZ+6dKlZn4kREREdFNJuQ7T1iTh+9QcKBUyLJvQV7KgA0j8zk5ZWRlCQkIQGxuLsWPHVlufk5NT5faPP/6I6dOnY9y4cVWWL168GDNmzDDddnFxaZ6CiYiI6LaulpRjalwSTueo4WyvwCePh6N/Vy9Ja5I07ERHRyM6OrrW9T4+VaeM/uabbzBo0CB07ty5ynIXF5dqY29Hq9VCq9WabqvVagCATqeDTqer93bu1M19mXOfVB37YBnYB8vAPlgGa+3DhYIyTFt3FJev34Cnsz0+ezwUvdu5NtvjqO92ZUII0SwVNJBMJsO2bdswZsyYGtfn5eWhffv2WLduHSZOnGha3qlTJ5SXl0On06FDhw6YOHEi5s2bBzu72nPcwoULsWjRomrLN27cCCen5p3YiIiIyBZllQKfnFGgVC+Dp0rgqZ4GeDk07z41Gg0mTpyI4uJiuLrWPgOz1ZygvG7dOri4uFQ73PXMM88gNDQUHh4eOHjwIBYsWICcnBy8//77tW5rwYIFmD9/vum2Wq2Gv78/hg0bdtsnq6npdDrEx8dj6NChUCqVZtsvVcU+WAb2wTKwD5bB2vrwa3oBVnyRAo3egJ6+Llg9JRRerVTNvt+bR2bqYjVhJy4uDpMmTYKDQ9WYeGtoCQ4Ohr29PZ588kksWbIEKlXNT7RKpapxnVKplOSHSqr9UlXsg2VgHywD+2AZrKEP36RcwQtbjkNnELj3Lk+snBwGFwfz1Fzf50bSq7Hq65dffkFaWhqeeOKJOsdGRUVBr9fjwoULzV8YERFRC/bZL+fx7KYU6AwCfw/2RdzUCLMFnYawind2Vq9ejbCwMISEhNQ5NiUlBXK5HN7e3maojIiIqOURQmDpzrP4ZP95AMDUezrhzb/3hFxu3skC60vSsFNaWor09HTT7czMTKSkpMDDwwMdOnQAUHk8bsuWLfj3v/9d7f4JCQk4fPgwBg0aBBcXFyQkJGDevHmYPHkyWrdubbbHQURE1FLoDEa8/HUqth69AgB4aUR3zL6vi9lnRW4IScNOcnIyBg0aZLp98/ybmJgYrF27FgCwadMmCCEwYcKEavdXqVTYtGkTFi5cCK1Wi4CAAMybN6/KeTxERETUNDQVejy14Sj2pV2DQi7D0rFBeCTcX+qy6iRp2Bk4cCDquvJ95syZmDlzZo3rQkNDcejQoeYojYiIiG5RWFaBaWuTcPxSERyUcnw8KRT3B7aVuqx6sYpzdoiIiEg6lwo1iFmTiPPXyuDupMTqmAiEdbSe00UYdoiIiKhWZ3LUiIlLxNUSLfzcHLB+eiTu8rauj2Vi2CEiIqIaHTpfgBnrk1FSrkf3ti5YFxsJH7dmnha5GTDsEBERUTU7T+bgmU0pqNAbEdnJA6umhMPNyfLm0KkPhh0iIiKq4n+HLuKNb05CCGBYz7ZYNqEvHJQKqctqNIYdIiIiAlA5WeAHu89h2Z5zAIAJkR3wjwd7wU5hFR+4UCuGHSIiIoLeYMQb35zCF4lZAIBnB3fFc0O6WvRkgfXFsENERNTClesMeOaLY/jpdB5kMuAfD/bG5Ls7Sl1Wk2HYISIiasGKNTrMWJ+MxAuFsLeTY9n4PhjR21fqspoUww4REVELlVtcjpi4RKTllcBFZYdVMeG4u7On1GU1OYYdIiKiFij9aili4hJxpegGvF1UWBcbiR6+rlKX1SwYdoiIiFqYo1nXEbs2CUUaHTp7OWNdbCT8PZykLqvZMOwQERG1ID+fzcNTG46iXGdEiL871kyNgIezvdRlNSuGHSIiohZiS/IlvLL1BAxGgYHd2+DjSaFwsrf9KGD7j5CIiKiFE0Jgxf4MvLMzDQAwNrQd/jUuGEornyywvhh2iIiIbJjRKLB4x2msPXgBAPDkfZ3xyohAm5gssL4YdoiIiGyUVm/AC1tS8d3xbADA66N64Im/dZa4KvNj2CEiIrJBJeU6zPrfEfyWXgClQob3HgnBg33aSV2WJBh2iIiIbMy1Ei2mrknEqWw1nOwVWDk5DAO6tZG6LMkw7BAREdmQC/llmBKXiKxCDTyd7bFmWgSC27tLXZakGHaIiIhsxMkrxZi6JhH5pRXw93DE+tgoBHg5S12W5Bh2iIiIbMCv5/Lx5OfJKKswoKevK9bGRsDbxUHqsiwCww4REZGV+/Z4Np7fnAKdQeCeLp745PEwuDgopS7LYjDsEBERWbG4XzOxeMdpAMCoYF+8/2gIVHYKiauyLAw7REREVkgIgXd2pWHFvgwAQEy/jnhrdC/I5S1nssD6YtghIiKyMjqDEa98fQJfH70MAHhxeHc8NbBLi5oVuSEYdoiIiKyIpkKPORuOYm/aNSjkMix5KAiPRvhLXZZFY9ghIiKyEtfLKjBtbRJSLhXBQSnH8omhGNyjrdRlWTyGHSIiIitw+boGU+IScf5aGdwclYibGoGwjq2lLssqMOwQERFZuLO5asTEJSJPrYWvmwPWx0aia1sXqcuyGgw7REREFuzw+QI8sT4ZJeV6dGvbCutiI+Hr5ih1WVaFYYeIiMhC/XQ6D/O2nECF3ojwjq2xOiYCbk6cLLChGHaIiIgs0G95Mnx16DiMAhjSoy3+O7EvHJScLLAx5FLu/MCBAxg9ejT8/Pwgk8mwffv2KuunTp0KmUxW5WvEiBFVxhQWFmLSpElwdXWFu7s7pk+fjtLSUjM+CiIioqYjhMBHP2dg83kFjAIYH+GPlZNDGXTugKRhp6ysDCEhIVi+fHmtY0aMGIGcnBzT1xdffFFl/aRJk3Dq1CnEx8djx44dOHDgAGbOnNncpRMRETU5g1Hgte0nsWxv5azIcwZ2xpKxQbBTSPrn2upJehgrOjoa0dHRtx2jUqng4+NT47ozZ85g586dSEpKQnh4OADgo48+wsiRI/Hee+/Bz8+vyWsmIiJqDuU6A57blIKdp3IhkwHjOhnw3OC7OCtyE7D4c3b27dsHb29vtG7dGvfffz/efvtteHp6AgASEhLg7u5uCjoAMGTIEMjlchw+fBgPPfRQjdvUarXQarWm22q1GgCg0+mg0+ma8dFUdXNf5twnVcc+WAb2wTKwD9JQ39Bh1sYUJF24DqVChnce6gn5lePsQx3q+/xYdNgZMWIExo4di4CAAGRkZODVV19FdHQ0EhISoFAokJubC29v7yr3sbOzg4eHB3Jzc2vd7pIlS7Bo0aJqy3/66Sc4OTk1+eOoS3x8vNn3SdWxD5aBfbAM7IP5FFcAK84okKORwUEh8ER3A+RXjgNgH+qi0WjqNc6iw8748eNN3wcFBSE4OBhdunTBvn37MHjw4EZvd8GCBZg/f77ptlqthr+/P4YNGwZXV9c7qrkhdDod4uPjMXToUCiVvJRQKuyDZWAfLAP7YF7nr5Uhdv0R5GjK0aaVPVZPCUMPXxf2oZ5uHpmpi0WHnb/q3LkzvLy8kJ6ejsGDB8PHxwdXr16tMkav16OwsLDW83yAyvOAVCpVteVKpVKSHyqp9ktVsQ+WgX2wDOxD8zuWdR2xa5NwXaNDgJcz1sdGwt+j6tEF9uH26vvcWNXp3ZcvX0ZBQQF8fX0BAP369UNRURGOHDliGvPzzz/DaDQiKipKqjKJiIhua2/aVUxcdRjXNTqEtHfDV7P6VQs61HQkfWentLQU6enpptuZmZlISUmBh4cHPDw8sGjRIowbNw4+Pj7IyMjASy+9hLvuugvDhw8HAPTo0QMjRozAjBkzsHLlSuh0OsydOxfjx4/nlVhERGSRvj5yGS99nQqDUWBAtzZYMSkUziqrOtBidSR9Zyc5ORl9+/ZF3759AQDz589H37598eabb0KhUCA1NRUPPPAAunXrhunTpyMsLAy//PJLlUNQGzZsQGBgIAYPHoyRI0eif//++PTTT6V6SERERDUSQmDl/gw8v+U4DEaBh/q2w+qYcAYdM5D0GR44cCCEELWu37VrV53b8PDwwMaNG5uyLCIioiZlNAq8/f0ZxP2WCQCYOaAzXhkRCLmcc+iYA+MkERFRM6rQG/HCluP49ng2AOC1kT0wY0BniatqWRh2iIiImkmpVo9Znx/Br+n5sJPL8N4jIRjTt53UZbU4DDtERETNIL9Ui2lrknDiSjGc7BVYMTkM93VrI3VZLRLDDhERURO7WFCGKXGJuFiggYezPdZMjUCIv7vUZbVYDDtERERN6OSVYkxdk4j80gq0b+2I9bGR6NymldRltWgMO0RERE3kYHo+Zn5+BKVaPXr4umLdtAh4uzpIXVaLx7BDRETUBL47no35m1OgMwjc3dkDn04Jh6sDP+rBEjDsEBER3aG1v2Vi0Y7TEAIYGeSDDx7rA5WdQuqy6A8MO0RERI0khMC7u9Lw8b4MAMCUfh3x1uheUHCyQIvCsENERNQIeoMRC7aewJYjlwEALwzrhjmD7oJMxqBjaRh2iIiIGuhGhQFzNx7FnrNXIZcB/3woCOMjO0hdFtWCYYeIiKgBrpdVYPq6JBzNKoLKTo7/TgzF0J5tpS6LboNhh4iIqJ6uFN1ATFwi0q+Wws1RidUx4Qjv5CF1WVQHhh0iIqJ6SMstQUxcInLV5fB1c8C62Eh0a+sidVlUDww7REREdUi6UIjpa5OgLtfjLu9WWB8bCT93R6nLonpi2CEiIrqNn07l4ukvjkGrNyKsY2usjgmHu5O91GVRAzDsEBER1eKLxCy8tu0EjAIY0sMbH00IhaM9Jwu0Ngw7REREfyGEwEc/p+P9+N8BAI+F++P/HuoNO4Vc4sqoMRh2iIiIbmEwCrz17Un871AWAGDuoLvw/LBunCzQijHsEBER/aFcZ8C8L1Pw48lcyGTAwtG9EHNPJ6nLojvEsENERARAXa7DjHXJOJxZCHuFHB881gejgn2lLouaAMMOERG1eHnqcsTEJeJsbglaqezw6ZQw3NPFS+qyqIkw7BARUYt2/lopHl+diCtFN9DGRYW10yLQy89N6rKoCTHsEBFRi5VyqQixa5NQWFaBTp5O+Hx6FPw9nKQui5oYww4REbVI+9KuYvb/juKGzoDg9m6ImxoBr1YqqcuiZsCwQ0RELc7Wo5fx0lep0BsF/tbVCysnh8FZxT+JtoqdJSKiFuXTAxn45w9nAQBj+vjhnYdDYG/HyQJtGcMOERG1CEajwD9/OIPPfs0EADzRPwCvjuwBuZyTBdo6hh0iIrJ5FXojXvrqOLanZAMAXh0ZiJkDukhcFZkLww4REdm0Uq0es/93BL+cy4edXIZ3Hg7G2ND2UpdFZsSwQ0RENiu/VIvYtUlIvVwMR6UCKyaHYmB3b6nLIjNj2CEiIpuUVaDBlLjDuFCggYezPeKmRqCPv7vUZZEEGHaIiMjmnMouRkxcEvJLtWjn7ojPp0eic5tWUpdFEmHYISIim3IwIx8z1x9BqVaPQB8XrIuNRFtXB6nLIglJOrHAgQMHMHr0aPj5+UEmk2H79u2mdTqdDi+//DKCgoLg7OwMPz8/TJkyBdnZ2VW20alTJ8hksipfS5cuNfMjISIiS/B9ag6mxiWhVKtHVIAHNs/qx6BD0oadsrIyhISEYPny5dXWaTQaHD16FG+88QaOHj2KrVu3Ii0tDQ888EC1sYsXL0ZOTo7p6+mnnzZH+UREZEHWHbyAuV8cRYXBiOjePlgXGwlXB6XUZZEFkPQwVnR0NKKjo2tc5+bmhvj4+CrL/vvf/yIyMhJZWVno0KGDabmLiwt8fHzqvV+tVgutVmu6rVarAVS+m6TT6RryEO7IzX2Zc59UHftgGdgHy2CNfRBC4IM96Vixv3KywImR7fHmqB5QwAidzihxdY1jjX2QQn2fH5kQQjRzLfUik8mwbds2jBkzptYxu3fvxrBhw1BUVARXV1cAlYexysvLodPp0KFDB0ycOBHz5s2DnV3tOW7hwoVYtGhRteUbN26EkxM/7ZaIyFoYBLD5vByHrlYeqBjpb8CwdgIyTorcImg0GkycOBHFxcWmXFATqwk75eXluPfeexEYGIgNGzaYlr///vsIDQ2Fh4cHDh48iAULFmDatGl4//33a91XTe/s+Pv7Iz8//7ZPVlPT6XSIj4/H0KFDoVTyrVapsA+WgX2wDNbUhxsVBjy3ORU/p12DXAYsfqAnHgu3jckCrakPUlKr1fDy8qoz7FjF1Vg6nQ6PPvoohBBYsWJFlXXz5883fR8cHAx7e3s8+eSTWLJkCVQqVY3bU6lUNa5TKpWS/FBJtV+qin2wDOyDZbD0PhRpKjB9/VEcuXgdKjs5PprQF8N61f90Bmth6X2QWn2fG4v/mNebQefixYuIj4+v852XqKgo6PV6XLhwwTwFEhGRWWUX3cDDKxNw5OJ1uDrY4X9PRNlk0KGmY9Hv7NwMOufOncPevXvh6elZ531SUlIgl8vh7c3pwImIbM3veSWIiUtETnE5fFwdsC42Et19XKQuiyycpGGntLQU6enpptuZmZlISUmBh4cHfH198fDDD+Po0aPYsWMHDAYDcnNzAQAeHh6wt7dHQkICDh8+jEGDBsHFxQUJCQmYN28eJk+ejNatW0v1sIiIqBkkXyjE9HXJKL6hw13erbAuNhLt3B2lLousgKRhJzk5GYMGDTLdvnn+TUxMDBYuXIhvv/0WANCnT58q99u7dy8GDhwIlUqFTZs2YeHChdBqtQgICMC8efOqnMdDRETWL/50HuZuPAqt3oi+HdwRFxOB1s72UpdFVkLSsDNw4EDc7mKwui4UCw0NxaFDh5q6LCIisiBfJmVhwdYTMApgcKA3/jsxFI72CqnLIiti0efsEBFRyyWEwPK96Xjvp98BAI+EtceSsUGwU1j8tTVkYRh2iIjI4hiMAou+O4X1CRcBAE8N7IIXh3eHjLMFUiMw7BARkUXR6g2Y92UKfjiRC5kMeOvvPTH13gCpyyIrxrBDREQWQ12uw8z1yTh0vhBKhQwfPNYHfw/2k7ossnIMO0REZBGuqssRsyYJZ3LUaKWyw6ePh+Geu7ykLotsAMMOERFJLjO/DI+vPozL12/Aq5UKa6dFoHc7N6nLIhvBsENERJI6fqkI09YmobCsAh09nfB5bBQ6eDpJXRbZEIYdIiKSzP7fr2H2/45AU2FAUDs3rJkWAa9WNX+IM1FjMewQEZEkth+7ghe2HIfeKPC3rl5YMTkMrVT8s0RNjz9VRERkdqsOnMf//XAGAPBAiB/eeyQE9nacLJCaB8MOERGZjdEosHTnWXx64DwAIPbeALw+qgfkck4WSM2HYYeIiMxCZzDipa9Sse3YFQDAguhAzBzQmbMiU7Nj2CEiomZXptVj9oajOPD7NSjkMrwzLhjjwtpLXRa1EAw7RETUrApKtYhdm4Tjl4vhqFTg48mhGNTdW+qyqAVh2CEiomZzqVCDKXGJyMwvQ2snJeKmRqBvh9ZSl0UtDMMOERE1i9PZasSsScS1Ei3auTti/fRIdGnTSuqyqAVi2CEioiaXkFGAmeuTUaLVI9DHBetiI9HW1UHqsqiFYtghIqIm9cOJHDy3KQUVBiMiAzywako43ByVUpdFLRjDDhERNZnPEy7gzW9PQQhgRC8ffDi+DxyUCqnLohaOYYeIiO6YEAIfxP+OZT+nAwAmRXXA4gd7Q8HJAskCMOwQEdEd0RuMeOObk/gi8RIAYN6Qbnhm8F2cLJAsBsMOERE1WrnOgLkbj2H3mTzIZcA/xvTGpKiOUpdFVAXDDhERNUqRpgJPrEtG8sXrsLeT46MJfTG8l4/UZRFVw7BDREQNllN8A1NWJ+Lc1VK4ONjhsynhiOrsKXVZRDVi2CEiogZJv1qCKasTkV1cjrauKqyLjUSgj6vUZRHVimGHiIjq7cjFQsSuTUbxDR06t3HG+thItG/tJHVZRLfFsENERPWy+3Qe5n5xFOU6I/p2cEdcTARaO9tLXRZRnRh2iIioTpuTL2HB1hMwGAXuD/TGfyf2hZM9/4SQdeBPKhER1UoIgY/3ZeDdXWkAgHGh7bF0XBCUCrnElRHVH8MOERHVyGgUWLzjNNYevAAAmD2wC14a3p2TBZLVYdghIqJqtHojXt5yDN+n5gAA3vx7T8T2D5C4KqLGYdghIqIqyvXAjM+PIuF8IZQKGf79aB88EOIndVlEjcawQ0REJtdKtFh2SoErmkI42yvwyePh6N/VS+qyiO6IpGeYHThwAKNHj4afnx9kMhm2b99eZb0QAm+++SZ8fX3h6OiIIUOG4Ny5c1XGFBYWYtKkSXB1dYW7uzumT5+O0tJSMz4KIiLbcCG/DI+uSsQVjQyezvb48sl+DDpkE+4o7FRUVCAtLQ16vb5R9y8rK0NISAiWL19e4/p33nkHy5Ytw8qVK3H48GE4Oztj+PDhKC8vN42ZNGkSTp06hfj4eOzYsQMHDhzAzJkzG1UPEVFLlXq5CONWHMTl6zfgqRL4cmYkerdzk7osoibRqLCj0Wgwffp0ODk5oVevXsjKygIAPP3001i6dGm9txMdHY23334bDz30ULV1Qgh8+OGHeP311/Hggw8iODgY69evR3Z2tukdoDNnzmDnzp347LPPEBUVhf79++Ojjz7Cpk2bkJ2d3ZiHRkTU4vxy7hrGf3oIBWUV6OXngud6G9DRg7Mik+1o1Dk7CxYswPHjx7Fv3z6MGDHCtHzIkCFYuHAhXnnllTsuLDMzE7m5uRgyZIhpmZubG6KiopCQkIDx48cjISEB7u7uCA8Pr1KDXC7H4cOHawxRAKDVaqHVak231Wo1AECn00Gn091x7fV1c1/m3CdVxz5YBvZBGt8ez8Er205CZxC4p7MH/vNILxw8sJd9kBh/H+qnvs9Po8LO9u3b8eWXX+Luu++uMt9Cr169kJGR0ZhNVpObmwsAaNu2bZXlbdu2Na3Lzc2Ft7d3lfV2dnbw8PAwjanJkiVLsGjRomrLf/rpJzg5mf9/M/Hx8WbfJ1XHPlgG9sF89mbLsP2iAgDQ19OIcW2u4uCBqwDYB0vBPtyeRqOp17hGhZ1r165VCxlA5Tk41jDZ1IIFCzB//nzTbbVaDX9/fwwbNgyurub75F6dTof4+HgMHToUSqXSbPulqtgHy8A+mI8QAu/+dA7bL14AAMT064BXR3SHXC5jHywE+1A/N4/M1KVRYSc8PBzff/89nn76aQAwBZzPPvsM/fr1a8wmq/Hx8QEA5OXlwdfX17Q8Ly8Pffr0MY25evVqlfvp9XoUFhaa7l8TlUoFlUpVbblSqZTkh0qq/VJV7INlYB+al85gxCtfp2Lr0SsAgJdHBGLWfZ2r/UeVfbAM7MPt1fe5aVTY+ec//4no6GicPn0aer0e//nPf3D69GkcPHgQ+/fvb8wmqwkICICPjw/27NljCjdqtRqHDx/G7NmzAQD9+vVDUVERjhw5grCwMADAzz//DKPRiKioqCapg4jIVmgq9Hhqw1HsS7sGhVyGpWOD8Ei4v9RlETW7Rl2N1b9/f6SkpECv1yMoKAg//fQTvL29kZCQYAod9VFaWoqUlBSkpKQAqDwpOSUlBVlZWZDJZHjuuefw9ttv49tvv8WJEycwZcoU+Pn5YcyYMQCAHj16YMSIEZgxYwYSExPx22+/Ye7cuRg/fjz8/DjbJxHRTYVlFZiw6jD2pV2Dg1KOVVPCGHSoxWj0DMpdunTBqlWr7mjnycnJGDRokOn2zfNoYmJisHbtWrz00ksoKyvDzJkzUVRUhP79+2Pnzp1wcHAw3WfDhg2YO3cuBg8eDLlcjnHjxmHZsmV3VBcRkS25VKhBzJpEnL9WBncnJeKmRiC0Q2upyyIym0aFnR9++AEKhQLDhw+vsnzXrl0wGo2Ijo6u13YGDhwIIUSt62UyGRYvXozFixfXOsbDwwMbN26sX+FERC3MmRw1YuIScbVEi3bujlgXG4G7vF2kLovIrBp1GOuVV16BwWCotlwI0SRz7BAR0Z07dL4Aj36SgKslWnRv64KvZ9/DoEMtUqPe2Tl37hx69uxZbXlgYCDS09PvuCgiIrozO0/m4JlNKajQGxHZyQOrpoTDzYlX9VDL1Kh3dtzc3HD+/Plqy9PT0+Hs7HzHRRERUeP979BFzN5wFBV6I4b1bIv10yMZdKhFa1TYefDBB/Hcc89VmS05PT0dzz//PB544IEmK46IiOpPCIH343/H69tPQghgQmQHrJgcBgelQurSiCTVqLDzzjvvwNnZGYGBgQgICEBAQAB69OgBT09PvPfee01dIxER1UFvMOLVbSexbM85AMCzg7vinw/1hkJu+bPaEzW3Rp2z4+bmhoMHDyI+Ph7Hjx+Ho6MjgoODMWDAgKauj4iI6lCuM+CZL47hp9N5kMmAfzzYG5Pv7ih1WUQWo9Hz7MhkMgwbNgzDhg1rynqIiKgBijU6zFifjMQLhbC3k2PZ+D4Y0du37jsStSD1DjvLli3DzJkz4eDgUOekfc8888wdF0ZERLeXW1yOmLhEpOWVwMXBDqumhOPuzp5Sl0Vkceoddj744ANMmjQJDg4O+OCDD2odJ5PJGHaIiJpZ+tVSxMQl4krRDXi7qLB+eiQCfVylLovIItU77GRmZtb4PRERmdfRrOuIXZuEIo0Onb2csS42Ev4eTlKXRWSxGnw1lk6nQ5cuXXDmzJnmqIeIiG7j57N5mLjqEIo0OoT4u+Or2fcw6BDVocEnKCuVSpSXlzdHLUREdBtbki/hla0nYDAKDOzeBh9PCoWTfaOvMyFqMRo1z86cOXPwr3/9C3q9vqnrISKivxBC4ON96Xjxq1QYjAJjQ9th1ZRwBh2iemrUb0pSUhL27NmDn376CUFBQdU+ImLr1q1NUhwRUUtnNAos3nEaaw9eAAA8eV9nvDIiEDIZJwskqq9GhR13d3eMGzeuqWshIqJbaPUGvLAlFd8dzwYAvPH3npjeP0DiqoisT4PCjtFoxLvvvovff/8dFRUVuP/++7Fw4UI4Ojo2V31ERC1SSbkOs/53BL+lF0CpkOG9R0LwYJ92UpdFZJUadM7O//3f/+HVV19Fq1at0K5dOyxbtgxz5sxprtqIiFqkayVaTFh1CL+lF8DZXoG4qREMOkR3oEFhZ/369fj444+xa9cubN++Hd999x02bNgAo9HYXPUREbUoF/LLMG7FQZy8ooansz02zeyHv3VtI3VZRFatQWEnKysLI0eONN0eMmQIZDIZsrOzm7wwIqKWJvVyEcatOIisQg38PRzx1ex7ENTeTeqyiKxeg87Z0ev1cHBwqLJMqVRCp9M1aVFERC3Ngd+vYdb/jkBTYUAvP1esmRYBbxeHuu9IRHVqUNgRQmDq1KlQqVSmZeXl5Zg1a1aVy8956TkRUf1tP3YFL2w5Dr1R4N67PLFychhcHJRSl0VkMxoUdmJiYqotmzx5cpMVQ0TU0nz2y3m8/X3lx+88EOKH9x4Jgb1do+Z7JaJaNCjsrFmzprnqICJqUYxGgSU/nsGqXyo/WDn23gC8PqoH5HJOFkjU1DjXOBGRmVXojXjpq+PYnlJ5cceC6EDMHNCZsyITNROGHSIiMyrV6jH7f0fwy7l82MlleOfhYIwNbS91WUQ2jWGHiMhM8ku1mLYmCSeuFMPJXoGPJ4ViYHdvqcsisnkMO0REZnCxoAxT4hJxsUADD2d7rJkagRB/d6nLImoRGHaIiJrZySvFmLomEfmlFfD3cMT62CgEeDnXfUciahIMO0REzejXc/l48vNklFUY0NPXFWtjOVkgkbkx7BARNZNvUionC9QZBO7p4olPHudkgURSYNghImoGt04W+PdgX/z70RCo7BQSV0XUMjHsEBE1IaNRYOnOs/j0wHkAwLR7O+GNUT05WSCRhBh2iIiaiM5gxEtfpWLbsSsAgJdHBGLWfZwskEhqDDtERE2gTKvH7A1HceD3a1DIZfjXuGA8HMbJAoksgcV/2lynTp0gk8mqfc2ZMwcAMHDgwGrrZs2aJXHVRNSS5JdqMWHVIRz4/RoclQp8FhPOoENkQSz+nZ2kpCQYDAbT7ZMnT2Lo0KF45JFHTMtmzJiBxYsXm247OTmZtUYiarmyCjSYEncYF/6YLDBuagT6cLJAIoti8WGnTZs2VW4vXboUXbp0wX333Wda5uTkBB8fn3pvU6vVQqvVmm6r1WoAgE6ng06nu8OK6+/mvsy5T6qOfbAM1tiHU9lqPPH5UeSXVqC9uwPiYsIQ4OVsVY/hr6yxD7aIfaif+j4/MiGEaOZamkxFRQX8/Pwwf/58vPrqqwAqD2OdOnUKQgj4+Phg9OjReOONN2777s7ChQuxaNGiass3btzId4WIqF7SimVYnSaH1iBDOyeBJ3sY4GYvdVVELYtGo8HEiRNRXFwMV1fXWsdZVdjZvHkzJk6ciKysLPj5+QEAPv30U3Ts2BF+fn5ITU3Fyy+/jMjISGzdurXW7dT0zo6/vz/y8/Nv+2Q1NZ1Oh/j4eAwdOhRKJScakwr7YBmsqQ87UnPw0taT0BkE7g5ojY8n9rGZyQKtqQ+2jH2oH7VaDS8vrzrDjsUfxrrV6tWrER0dbQo6ADBz5kzT90FBQfD19cXgwYORkZGBLl261LgdlUoFlUpVbblSqZTkh0qq/VJV7INlsPQ+xP2aicU7TgMARgX74n0bnSzQ0vvQUrAPt1ff58Zqws7Fixexe/fu275jAwBRUVEAgPT09FrDDhFRQwlROVngJ/srJwucek8nvPl3ThZIZA2sJuysWbMG3t7eGDVq1G3HpaSkAAB8fX3NUBURtQQ6gxEvf52KrUcrJwt8cXh3PDWwCycLJLISVhF2jEYj1qxZg5iYGNjZ/VlyRkYGNm7ciJEjR8LT0xOpqamYN28eBgwYgODgYAkrJiJbUabV46kNR7H/j8kCl44NwiPh/lKXRUQNYBVhZ/fu3cjKykJsbGyV5fb29ti9ezc+/PBDlJWVwd/fH+PGjcPrr78uUaVEZEsKSrWIXZuE45eL4ahU4ONJoRgU6C11WUTUQFYRdoYNG4aaLhrz9/fH/v37JaiIiGzdpUINpsQlIjO/DK2dlIibGoG+HVpLXRYRNYJVhB0iInM6lV2MqWuScK1Ei3bujlg/PRJd2rSSuiwiaiSGHSKiWxxMz8fMz4+gVKtHoI8L1sVGoq2rg9RlEdEdYNghIvrDjtRszP/yOCoMRkQFeODTKeFwc+QcJ0TWjmGHiAjA2t8ysWjHaQgBjAzywfuP9oGD0vYmCyRqiRh2iKhFE0LgnV1pWLEvAwAwpV9HvDW6FxScLJDIZjDsEFGLpTMY8crXJ/D10csAOFkgka1i2CGiFklTocecDUexN61yssAlDwXh0QhOFkhkixh2iKjFKSyrwLS1STh+qQgOSjmWTwzF4B5tpS6LiJoJww4RtSiXCjWIiUvE+fwyuDspsTomAmEdOVkgkS1j2CGiFuN0thoxaxJNkwWui43AXd4uUpdFRM2MYYeIWoSEjALMXJ+MEq0e3dtWThbo48bJAolaAoYdIrJ5P5zIwXObUlBhMCIywAOrOFkgUYvCsENENm3dwQtY+N0pCAGM6OWDD8dzskCiloZhh4hskhAC7/2UhuV7KycLnHx3Byx6oDcnCyRqgRh2iMjm/HWywOeHdsPc++/iZIFELRTDDhHZlDKtHrM3HMWB3ysnC/znQ73xWEQHqcsiIgkx7BCRzbhWokXs2iScuFIMR6UCyyf1xf2BnCyQqKVj2CEim5CZX4aYuERkFWrg4WyPuKkR6OPvLnVZRGQBGHaIyOqlXCpC7NokFJZVoIOHE9bFRiLAy1nqsojIQjDsEJFV+/lsHuZsOIYbOgOC2rkhbmoE2riopC6LiCwIww4RWa0vk7Lw6raTMBgFBnRrgxWTQuGs4ssaEVXFVwUisjpCCCzbk44Pdv8OABgb2g7/GhcMpUIucWVEZIkYdojIqugNRrzxzSl8kZgFAJgzqAteGNadc+gQUa0YdojIatyoMODpL45i95mrkMmARQ/0wpR+naQui4gsHMMOEVmFwrIKTF+XhGNZRbC3k2PZ+L4Y0dtH6rKIyAow7BCRxbtUqEFMXCLO55fBzVGJz2LCEdHJQ+qyiMhKMOwQkUU7eaUY09Ym4VqJFn5uDlgXG4mubV2kLouIrAjDDhFZrF/OXcOsz4+grMKAQB8XrJ0WCR83B6nLIiIrw7BDRBZp27HLeHFLKvRGgX6dPfHJlDC4OiilLouIrBDDDhFZFCEEVu7PwNIfzwIARof44b1HgqGyU0hcGRFZK4YdIrIYRgH844c0fH6ocg6dJ/oH4NWRPSCXcw4dImo8hh0isghanQHrfpcjpbAy6Lw+qgee+FtniasiIlvAsENEkivW6DB93RGkFMqhVMjw70f74IEQP6nLIiIbYdEfJLNw4ULIZLIqX4GBgab15eXlmDNnDjw9PdGqVSuMGzcOeXl5ElZMRA2VXXQDD688iOSLRXBQCMRNCWPQIaImZdFhBwB69eqFnJwc09evv/5qWjdv3jx899132LJlC/bv34/s7GyMHTtWwmqJqCHO5qox9uODOHe1FG1dVHimlwF3d+ZkgUTUtCz+MJadnR18fKpPCV9cXIzVq1dj48aNuP/++wEAa9asQY8ePXDo0CHcfffd5i6ViBogIaMAMz9PRkm5Hnd5t8Lqx/si5eBeqcsiIhtk8WHn3Llz8PPzg4ODA/r164clS5agQ4cOOHLkCHQ6HYYMGWIaGxgYiA4dOiAhIeG2YUer1UKr1Zpuq9VqAIBOp4NOp2u+B/MXN/dlzn1SdeyD+f1wIhcvfH0COoNAWAd3rJzUF85/TKHDPkiLvw+WgX2on/o+PzIhhGjmWhrtxx9/RGlpKbp3746cnBwsWrQIV65cwcmTJ/Hdd99h2rRpVUILAERGRmLQoEH417/+Vet2Fy5ciEWLFlVbvnHjRjg5OTX54yCiSkIAe3Nk+OZi5Zw5wR5GPH6XEfacQoeIGkGj0WDixIkoLi6Gq6trreMs+p2d6Oho0/fBwcGIiopCx44dsXnzZjg6OjZ6uwsWLMD8+fNNt9VqNfz9/TFs2LDbPllNTafTIT4+HkOHDoVSyZlhpcI+mIfBKPB/P5zFNxcvAQAej/LHayMDofhjDh32wTKwD5aBfaifm0dm6mLRYeev3N3d0a1bN6Snp2Po0KGoqKhAUVER3N3dTWPy8vJqPMfnViqVCiqVqtpypVIpyQ+VVPulqtiH5nOjwoBnvjyG+NOVV0u+NrIHnvhbAGSy6pMFsg+WgX2wDOzD7dX3ubH4q7FuVVpaioyMDPj6+iIsLAxKpRJ79uwxrU9LS0NWVhb69esnYZVEdKuCUi0mrDqE+NN5sLeTY/nEUMwY0LnGoENE1Bws+p2dF154AaNHj0bHjh2RnZ2Nt956CwqFAhMmTICbmxumT5+O+fPnw8PDA66urnj66afRr18/XolFZCEy88swdU0iLhZo4O6kxKop4YjoxEvLici8LDrsXL58GRMmTEBBQQHatGmD/v3749ChQ2jTpg0A4IMPPoBcLse4ceOg1WoxfPhwfPzxxxJXTUQAcOTidTyxLgnXNTq0b+2IdbGR6NKmldRlEVELZNFhZ9OmTbdd7+DggOXLl2P58uVmqoiI6mPnyVw8u+kYtHojgtu7YXVMBNq4VD9PjojIHCw67BCR9VnzWyYW7zgNIYDBgd74aGJfONnzpYaIpMNXICJqEkajwP/9cAarf80EAEyK6oBFD/SCncKqroMgIhvEsENEd6xcZ8C8L1Pw48lcAMDLIwIx6z5ecUVEloFhh4juyPWyCjyxPhlHLl6HvUKOdx8JxoN92kldFhGRCcMOETVaVoEGU9ck4nx+GVwd7PDplHDc3dlT6rKIiKpg2CGiRkm5VITpa5NQUFaBdu6OWDMtAt3aukhdFhFRNQw7RNRg8afz8PQXR1GuM6KXnyvipkagrauD1GUREdWIYYeIGuTzhAt469tTMArgvm5tsHxSKFqp+FJCRJaLr1BEVC9Go8DSnWfx6YHzAIDxEf74x5jeUPLSciKycAw7RFSnGxUGPPflMew6Vfmp5c8P7Ya599/FS8uJyCow7BDRbV1Vl+OJ9clIvVzMS8uJyCox7BBRrc7mqhG7JgnZxeVo/cenlofzU8uJyMow7BBRjfalXcXcjcdQqtWjs5cz4qZGoJOXs9RlERE1GMMOEVXz+aGLWPjtKRiMAnd39sDKyWFwd7KXuiwiokZh2CEiE4NRYMkPZ/DZHx/m+XBYe/zzoSDY2/GKKyKyXgw7RAQA0FTo8eymFMSfrrzi6sXh3fHUwC684oqIrB7DDhEhT12OJ9Yl48SVYtjbyfHvR0IwOsRP6rKIiJoEww5RC3c6W43p65KQU1wOD2d7rJoShrCOvOKKiGwHww5RC7b37FXM3XgUZRUGdGnjjDVTI9HB00nqsoiImhTDDlELtT7hAhb+8RlX93TxxIpJYXBzUkpdFhFRk2PYIWph9AYj3v7+DNYevAAAeDS8Pd4ewyuuiMh2MewQtSDFGh3mbDyKX9PzAfCKKyJqGRh2iFqI89dK8cS6ZJzPL4OTvQIfPNYHw3v5SF0WEVGzY9ghagF+PZePpzYcgbpcDz83B3wWE4Gefq5Sl0VEZBYMO0Q2TAiBzw9dxKLvTsNgFAjt4I5PHg9HGxeV1KUREZkNww6RjdIZjFj47SlsOJwFABgb2g5LxgZBZaeQuDIiIvNi2CGyQdfLKvDUhqNIOF8AmQx4ZUQgZg7ozBORiahFYtghsjHpV0swfV0yLhZo4GyvwH/G98WQnm2lLouISDIMO0Q2ZF/aVTy98RhKtHq0b+2Iz2LCEejDE5GJqGVj2CGyAUIIfHLgPN7ZeRZGAUR28sCKyaHwbMUTkYmIGHaIrJymQo8Xv0rF96k5AIDHwv3xjzG9OSMyEdEfGHaIrNjFgjI8+fkRnM0tgVIhw1uje2FSVAeeiExEdAuGHSIrtf/3a3jmi2MovqGDVysVVk4ORXgnD6nLIiKyOAw7RFZGCIGV+8/j3V2V5+f08XfHyslh8HFzkLo0IiKLZNEH9ZcsWYKIiAi4uLjA29sbY8aMQVpaWpUxAwcOhEwmq/I1a9YsiSomal5lWj3mbjyGf/1xIvL4CH98+eTdDDpERLdh0e/s7N+/H3PmzEFERAT0ej1effVVDBs2DKdPn4azs7Np3IwZM7B48WLTbScnJynKJWpWFwvKMHP9EaTlVZ6fs/CBXpgU1VHqsoiILJ5Fh52dO3dWub127Vp4e3vjyJEjGDBggGm5k5MTfHzq/+nNWq0WWq3WdFutVgMAdDoddDrdHVZdfzf3Zc59UnXW0IcD5/Ixb3Mq1OV6tGllj4/GhyCsY2uLrrmhrKEPLQH7YBnYh/qp7/MjE0KIZq6lyaSnp6Nr1644ceIEevfuDaDyMNapU6cghICPjw9Gjx6NN95447bv7ixcuBCLFi2qtnzjxo18V4gsilEA8Vdk+PGSHAIydGolENvdADd7qSsjIpKeRqPBxIkTUVxcDFfX2idQtZqwYzQa8cADD6CoqAi//vqrafmnn36Kjh07ws/PD6mpqXj55ZcRGRmJrVu31rqtmt7Z8ff3R35+/m2frKam0+kQHx+PoUOHQqlUmm2/VJWl9qGwrAIvfHUCv6QXAAAeC2+HN0b1gMpG58+x1D60NOyDZWAf6ketVsPLy6vOsGPRh7FuNWfOHJw8ebJK0AGAmTNnmr4PCgqCr68vBg8ejIyMDHTp0qXGbalUKqhU1WeWVSqVkvxQSbVfqsqS+nA06zrmbjiK7OJyOCjleHtMEB4Oay91WWZhSX1oydgHy8A+3F59nxurCDtz587Fjh07cODAAbRvf/sX/KioKACVh7xqCztElkoIgXUHL+D/fjgDnUEgwMsZKyaH8vOtiIjugEWHHSEEnn76aWzbtg379u1DQEBAnfdJSUkBAPj6+jZzdURNq6Rch1e+PoHvT1R+7MPIIB/8a1wwXBz4vzoiojth0WFnzpw52LhxI7755hu4uLggNzcXAODm5gZHR0dkZGRg48aNGDlyJDw9PZGamop58+ZhwIABCA4Olrh6ovo7m6vGU/87ivP5ZbCTy/DqyB6Ydm8nfuwDEVETsOiws2LFCgCVV1zdas2aNZg6dSrs7e2xe/dufPjhhygrK4O/vz/GjRuH119/XYJqiRpOCIENh7Pwjx2nodUb4evmgP9ODEVYx9ZSl0ZEZDMsOuzUdaGYv78/9u/fb6ZqiJpWsUaHV7am4seTle9Y3tetDd5/NASeraqfPE9ERI1n0WGHyFYlXyjEs5tScKXoBpQKGV4eEYjYewMgl/OwFRFRU2PYITIjg1Hg473p+HDPORiMAh09nfDRhL4Ibu8udWlERDaLYYfITPLU5XhuUwoSzldOEjimjx/+MaY3r7YiImpmDDtEZvB9ag5e234CRRodnOwVWPxgb4wLbcerrYiIzIBhh6gZFd/Q4a1vTmJ7SjYAoJefK5ZN6IsubVpJXBkRUcvBsEPUTH5Lz8cLW44jp7gcchnw1MC78MzgrrC30c+2IiKyVAw7RE2sXGfA0h/PYu3BCwCATp5O+PejfTh3DhGRRBh2iJpQ6uUizPsyBRnXygAAk6I64LVRPeBkz181IiKp8BWYqAmU6wz4YPfvWHXgPIwCaOOiwjsPB2NQd2+pSyMiavEYdoju0KHzBXjl61RcKNAAAEaH+GHxA73Q2tle4sqIiAhg2CFqNHW5Dkt/PIuNh7MAAD6uDnh7TG8M6dlW4sqIiOhWDDtEjbDnTB5e23YSuepyAMDEqA54JToQrpwgkIjI4jDsEDVAdtEN/N/3Z/D9iRwAlVdaLRkbjH5dPCWujIiIasOwQ1QPFXojVv+aiWV7zuGGzgCFXIbp/QMwb0g3ONorpC6PiIhug2GHqA6/nsvHm9+exPk/LieP6NQaix/sjR6+rhJXRkRE9cGwQ1SLvx6y8mqlwqsjA/FQX36mFRGRNWHYoRZPln0M95xbAlm2L9AxEiXlOnyy/zw++/U8ynVGKOQyTOnXEfOGduMJyEREVohhh1o82YnNaFN6BrrUzfg82xsf7j6HgrIKAEBkJw8serAXD1kREVkxhp1blFWUQVFR/WRTZ3tn0/fl+nIYjIZat9GQsUr8+S6BVq+F3qivdayT0sl06KSusY5KR8hllR82WWGogM6ga5KxDnYOUMgVDR6rM+hQYaiodazKTgU7uV2Dx+qNemj12lrH2ivsoVQoax5bfAnQFAKQQZz6GioIlB7ZjE3aTvCBAZ1bt8bkEf0xONAbMpkMZRVlprsqFUrYKyonDDQYDSjXl9daw61jjcKIG7obTTLWTm4HlZ0KACCEgEanaZKxCrkCDnYOptu3Pu47GSuXyeGodLztWJ1Oh3JDOW7obkCp/PN3Q6PTQAhR43ZlMhmclE6NGntDdwNGYay15lt/lxsytilfIxrye99UrxE3+1BWUQalULbc14jbjG3I731jXyP+2ofbja2JLb5G1Da2Phh2buH3bz/AoeoyJ6UTyl7980kft3kcfjj3Q63bEG/9+UL7+LbH8dXpr2ode/2F66bvn9zxJNYdX1fr2KsvXEUb5zYAgPm75uPj5I9rHZv5bCY6uXcCALy25zW8l/BerWNPzj6JXt69AAD//OWfWLR/Ua1jE59IRES7CADAfw79By/tfqnWsXtj9mJgp4EAgE+PfIq5P86tdeyOCTswqtsoAMCGExsw7ZtptY7d/PBmPNLrEQDAtjPb8OhXj9Y6ds2DazC1z1QAwK70Xfj7F3+vdex/4YDZohjfq17DPugxqFyDr7bXPPadIe/gxXtfBAAczTmKyM8ia93uW/e9hYUDFwIAzlw7g94retc69oV+L+DdYe8CALKKsxDwn4Baxz4V/hSWj1oOAMjX5MP7vdo/liImJAZrx6wFUBkGWi1pVevYh3s+jC2PbDHdvt3YkV1H4vuJ35tue7/nXeuL5H0d78O+qftMtzv9pxPyNfk1jg3LD0PyzGTT7Z7Le+Ji8cUax/Zs0xOnnjpluh2xKgKnr52ucWxHt4648NwF0+0BawcgOTu5xrFeTl649uI10+3oDdHYf3F/jWOb8zWidEGpKRyZ/TXiROU/fI2o9N/o/2JO5BwAwC9Zv2DQukG1jm3S14gTf37L14hK4X7hSJqRVOt+ayJv0GgiGya/ec6xjJeSExHZEpmo7T3fFkStVsPNzQ3Z17Lh6lr93IzmPIz1448/YuTIkTDKjDyM1cCxDX2LulxXjoTzBfh4XzqOXCxCD9kFbFVV/i/VHoASlc+v4YmfUe4dWOt2eRir4WPrexhr165diB4RDVenP38PeRjL/Iexdu3aheHDh0Op5GGsmsaa6zDWrX243dia2OJrRE1jb/79Li4urvHv9008jHULZ3vnKi9ENbm1cXWpa6xO9+cLgcpOBRVU9dpuQ8baK+xNvxxSjVUqlKYXiaYcaye3g5193T/CRqPA3rMFWLk/A0cuVh46dLBzwkO9OsE5TQYBGWQQpn8VckWdPwc3NWSsXCZvlrEymaxZxgIw61idTAcHhUO1Y/G3BpS6NGRsQ475N2RsU75G3MpcrxE3++Bs71zl3KmaxjZku7cj9WtEQ8ea4zXidn3469i62MprxJ1g2CGbpanQ46sjl7HmtwvIzK/8X4K9nRwTIztg9sAuaCsKgCveEC7tcNwuBMH645CVXAH+OO+BiIhsA8MO2Zyc4htYe/ACvjicBXV55Vv5Lg52mBjZAbH9A9DW9eb/ptsBz52EwSjDxR9/RK/odyGXC8Cufv8jJiIi68CwQzZBbzDiwLlr2JR4CXvOXoXBWHneRidPJ0y7NwAPh7WHs6qGH3c7FXDzcKJMBtjV7213IiKyHgw7ZNWyCjTYnHwJW45cQp76z5MLowI88MTfOuP+QG8o5PxoByKiloxhh6xOQakWu07l4bvj2Ug4X2Ba3tpJibGh7fFYhD+6tXWRsEIiIrIkDDtkFa6XVWDXqVx8fyIHBzMKTIepZDLgb13b4LFwfwzp6Q2VHefIISKiqhh2yCIJIXDuain2pV3FvrRrSMwshN745/wpQe3cMCrYF38P9kX71vW/3JiIiFoehh2yGIVlFUjMLMSBc9ewP+0arhRVnTCrp68rRgX7YlSQLzp5Ne0cDEREZLsYdkgSQgjkFJcj6UIhEjMrv85dLa0yxt5Ojrs7e2JQ9zYY1N2bAYeIiBqFYYeanRACV4pu4OQVNU5lF+PElWKcvFKM/NLqU7539W6Ffl08Mai7N+7u7AlHe56DQ0REd8Zmws7y5cvx7rvvIjc3FyEhIfjoo48QGVn7J81S0yvT6pFVqEHGtVJkXC1DxrVSnM8vxflrZdBUVP/8H4Vchl5+rojo5IHIAA9EdPKAhzPnuSEioqZlE2Hnyy+/xPz587Fy5UpERUXhww8/xPDhw5GWlgZv79o/1p7qZjQKqMt1uK7RobCsAtfLKlCoqcBVdTmyi8uRU3QDOcXlyC66YZqtuCZ2chm6tnVBUDtX9G7nht7t3NDDx5Xv3BARUbOzibDz/vvvY8aMGZg2bRoAYOXKlfj+++8RFxeHV155pd7buVyogYveDjc/NFmg8ps/b//x7x8L/rx9cwt/jv/rumrbEoBer8flMuB0jhoKRdVW1HS/+uxfZxDQGwR0BuMfXwJ6oxEVeiP0RmFaVq4z4EaFAWUV+j/+NUCj1UNTYYCmQo9SrR5FGh2uaypgrPlDpGvk7qRElzat0NnLGV28//y3g4cTlAp5/TdERETURKw+7FRUVODIkSNYsGCBaZlcLseQIUOQkJBQ4320Wi202j9n21Wr1QCAEf/5BXKVuS9jtsO7qYfMvM+Gc1Yp0NrJHh5OSrg7KdHGRQVfVwf4ulV++fzxb6uaPpIBAIwG6IzVD2VZgpufPn/rp9CT+bEPloF9sAzsQ/3U9/mx+rCTn58Pg8GAtm3bVlnetm1bnD17tsb7LFmyBIsWLaq2XCkXUMirvo0h+8s3sr8uv82YKotvc/+/bqO2dTJZzctv/V4hBxSyv3zJhel7OxkglwFKOaBSAPYKQCUXf/x76zLA2U7AWQk42wF2cj0AbdUCtACuAiVXgRIA52Dd4uPjpS6BwD5YCvbBMrAPt6fRaOo1zurDTmMsWLAA8+fPN91Wq9Xw9/dH4quD4erqarY6dDod4uPjMXToUCiVSrPtl6piHywD+2AZ2AfLwD7Uz80jM3Wx+rDj5eUFhUKBvLy8Ksvz8vLg4+NT431UKhVUKlW15UqlUpIfKqn2S1WxD5aBfbAM7INlYB9ur77PjdWfMWpvb4+wsDDs2bPHtMxoNGLPnj3o16+fhJURERGRJbD6d3YAYP78+YiJiUF4eDgiIyPx4YcfoqyszHR1FhEREbVcNhF2HnvsMVy7dg1vvvkmcnNz0adPH+zcubPaSctERETU8thE2AGAuXPnYu7cuVKXQURERBbG6s/ZISIiIrodhh0iIiKyaQw7REREZNMYdoiIiMimMewQERGRTWPYISIiIpvGsENEREQ2jWGHiIiIbBrDDhEREdk0m5lB+U4IIQDU/6Pim4pOp4NGo4Farean2kqIfbAM7INlYB8sA/tQPzf/bt/8O14bhh0AJSUlAAB/f3+JKyEiIqKGKikpgZubW63rZaKuONQCGI1GZGdnw8XFBTKZzGz7VavV8Pf3x6VLl+Dq6mq2/VJV7INlYB8sA/tgGdiH+hFCoKSkBH5+fpDLaz8zh+/sAJDL5Wjfvr1k+3d1deUPswVgHywD+2AZ2AfLwD7U7Xbv6NzEE5SJiIjIpjHsEBERkU1j2JGQSqXCW2+9BZVKJXUpLRr7YBnYB8vAPlgG9qFp8QRlIiIisml8Z4eIiIhsGsMOERER2TSGHSIiIrJpDDtERERk0xh2mtnChQshk8mqfAUGBprWl5eXY86cOfD09ESrVq0wbtw45OXlSVixbThw4ABGjx4NPz8/yGQybN++vcp6IQTefPNN+Pr6wtHREUOGDMG5c+eqjCksLMSkSZPg6uoKd3d3TJ8+HaWlpWZ8FNavrj5MnTq12u/HiBEjqoxhH+7ckiVLEBERARcXF3h7e2PMmDFIS0urMqY+r0VZWVkYNWoUnJyc4O3tjRdffBF6vd6cD8Wq1acPAwcOrPY7MWvWrCpj2IeGY9gxg169eiEnJ8f09euvv5rWzZs3D9999x22bNmC/fv3Izs7G2PHjpWwWttQVlaGkJAQLF++vMb177zzDpYtW4aVK1fi8OHDcHZ2xvDhw1FeXm4aM2nSJJw6dQrx8fHYsWMHDhw4gJkzZ5rrIdiEuvoAACNGjKjy+/HFF19UWc8+3Ln9+/djzpw5OHToEOLj46HT6TBs2DCUlZWZxtT1WmQwGDBq1ChUVFTg4MGDWLduHdauXYs333xTiodklerTBwCYMWNGld+Jd955x7SOfWgkQc3qrbfeEiEhITWuKyoqEkqlUmzZssW07MyZMwKASEhIMFOFtg+A2LZtm+m20WgUPj4+4t133zUtKyoqEiqVSnzxxRdCCCFOnz4tAIikpCTTmB9//FHIZDJx5coVs9VuS/7aByGEiImJEQ8++GCt92EfmsfVq1cFALF//34hRP1ei3744Qchl8tFbm6uacyKFSuEq6ur0Gq15n0ANuKvfRBCiPvuu088++yztd6HfWgcvrNjBufOnYOfnx86d+6MSZMmISsrCwBw5MgR6HQ6DBkyxDQ2MDAQHTp0QEJCglTl2rzMzEzk5uZWed7d3NwQFRVlet4TEhLg7u6O8PBw05ghQ4ZALpfj8OHDZq/Zlu3btw/e3t7o3r07Zs+ejYKCAtM69qF5FBcXAwA8PDwA1O+1KCEhAUFBQWjbtq1pzPDhw6FWq3Hq1CkzVm87/tqHmzZs2AAvLy/07t0bCxYsgEajMa1jHxqHHwTazKKiorB27Vp0794dOTk5WLRoEf72t7/h5MmTyM3Nhb29Pdzd3avcp23btsjNzZWm4Bbg5nN764vFzds31+Xm5sLb27vKejs7O3h4eLA3TWjEiBEYO3YsAgICkJGRgVdffRXR0dFISEiAQqFgH5qB0WjEc889h3vvvRe9e/cGgHq9FuXm5tb4O3NzHTVMTX0AgIkTJ6Jjx47w8/NDamoqXn75ZaSlpWHr1q0A2IfGYthpZtHR0abvg4ODERUVhY4dO2Lz5s1wdHSUsDIi6Y0fP970fVBQEIKDg9GlSxfs27cPgwcPlrAy2zVnzhycPHmyyrmDZH619eHW89GCgoLg6+uLwYMHIyMjA126dDF3mTaDh7HMzN3dHd26dUN6ejp8fHxQUVGBoqKiKmPy8vLg4+MjTYEtwM3n9q9Xmtz6vPv4+ODq1atV1uv1ehQWFrI3zahz587w8vJCeno6APahqc2dOxc7duzA3r170b59e9Py+rwW+fj41Pg7c3Md1V9tfahJVFQUAFT5nWAfGo5hx8xKS0uRkZEBX19fhIWFQalUYs+ePab1aWlpyMrKQr9+/SSs0rYFBATAx8enyvOuVqtx+PBh0/Per18/FBUV4ciRI6YxP//8M4xGo+nFh5re5cuXUVBQAF9fXwDsQ1MRQmDu3LnYtm0bfv75ZwQEBFRZX5/Xon79+uHEiRNVwmd8fDxcXV3Rs2dP8zwQK1dXH2qSkpICAFV+J9iHRpD6DGlb9/zzz4t9+/aJzMxM8dtvv4khQ4YILy8vcfXqVSGEELNmzRIdOnQQP//8s0hOThb9+vUT/fr1k7hq61dSUiKOHTsmjh07JgCI999/Xxw7dkxcvHhRCCHE0qVLhbu7u/jmm29EamqqePDBB0VAQIC4ceOGaRsjRowQffv2FYcPHxa//vqr6Nq1q5gwYYJUD8kq3a4PJSUl4oUXXhAJCQkiMzNT7N69W4SGhoquXbuK8vJy0zbYhzs3e/Zs4ebmJvbt2ydycnJMXxqNxjSmrtcivV4vevfuLYYNGyZSUlLEzp07RZs2bcSCBQukeEhWqa4+pKeni8WLF4vk5GSRmZkpvvnmG9G5c2cxYMAA0zbYh8Zh2Glmjz32mPD19RX29vaiXbt24rHHHhPp6emm9Tdu3BBPPfWUaN26tXBychIPPfSQyMnJkbBi27B3714BoNpXTEyMEKLy8vM33nhDtG3bVqhUKjF48GCRlpZWZRsFBQViwoQJolWrVsLV1VVMmzZNlJSUSPBorNft+qDRaMSwYcNEmzZthFKpFB07dhQzZsyockmtEOxDU6ipBwDEmjVrTGPq81p04cIFER0dLRwdHYWXl5d4/vnnhU6nM/OjsV519SErK0sMGDBAeHh4CJVKJe666y7x4osviuLi4irbYR8aTiaEEOZ7H4mIiIjIvHjODhEREdk0hh0iIiKyaQw7REREZNMYdoiIiMimMewQERGRTWPYISIiIpvGsENEREQ2jWGHiIiIbBrDDhEREdk0hh0isikGgwH33HMPxo4dW2V5cXEx/P398dprr0lUGRFJhR8XQUQ25/fff0efPn2watUqTJo0CQAwZcoUHD9+HElJSbC3t5e4QiIyJ4YdIrJJy5Ytw8KFC3Hq1CkkJibikUceQVJSEkJCQqQujYjMjGGHiGySEAL3338/FAoFTpw4gaeffhqvv/661GURkQQYdojIZp09exY9evRAUFAQjh49Cjs7O6lLIiIJ8ARlIrJZcXFxcHJyQmZmJi5fvix1OUQkEb6zQ0Q26eDBg7jvvvvw008/4e233wYA7N69GzKZTOLKiMjc+M4OEdkcjUaDqVOnYvbs2Rg0aBBWr16NxMRErFy5UurSiEgCfGeHiGzOs88+ix9++AHHjx+Hk5MTAOCTTz7BCy+8gBMnTqBTp07SFkhEZsWwQ0Q2Zf/+/Rg8eDD27duH/v37V1k3fPhw6PV6Hs4iamEYdoiIiMim8ZwdIiIismkMO0RERGTTGHaIiIjIpjHsEBERkU1j2CEiIiKbxrBDRERENo1hh4iIiGwaww4RERHZNIYdIiIismkMO0RERGTTGHaIiIjIpv0/r4AeLyIeq7cAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(s, res)\n",
+    "plt.plot(s[len(s)//2], v, \"*\")\n",
+    "plt.hlines(v, 0, s[-1],\"g\", \"dashed\")\n",
+    "plt.xlabel(\"X\")\n",
+    "plt.ylabel(\"Price\")\n",
+    "plt.xlim((s[0], s[-1]))\n",
+    "plt.grid()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "58875619",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Option value is $9.30\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Option value is ${v:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e12327e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -224,3 +224,81 @@ def test_put_option():
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
 
     assert v == approx(v0, 1e-1)
+
+def test_american_call():
+    stock_price = 50.0
+    risk_free_rate = 0.06
+    dividend_yield = 0.05
+    volatility = 0.40
+
+    valuation_date = Date(1, 1, 2016)
+    expiry_date = Date(1, 1, 2021)
+    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+    num_steps = 100
+    strike_price = 50.0
+    payoff = EquityTreePayoffTypes.VANILLA_OPTION
+    exercise = EquityTreeExerciseTypes.AMERICAN
+    option_type = OptionTypes.AMERICAN_CALL
+    params = np.array([1.0, strike_price])
+
+    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
+                                           dividend_yield=dividend_yield, sigma=volatility,
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=strike_price, digital=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+    tree = EquityBinomialTree()
+    value = tree.value(
+        stock_price,
+        discount_curve,
+        dividend_curve,
+        volatility,
+        num_steps,
+        valuation_date,
+        payoff,
+        expiry_date,
+        payoff,
+        exercise,
+        params)  # price, delta, gamma, theta
+    assert v == approx(value[0], abs=1e-1)
+
+
+def test_american_put():
+    stock_price = 50.0
+    risk_free_rate = 0.06
+    dividend_yield = 0.05
+    volatility = 0.40
+
+    valuation_date = Date(1, 1, 2016)
+    expiry_date = Date(1, 1, 2021)
+    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+    num_steps = 100
+    strike_price = 50.0
+    payoff = EquityTreePayoffTypes.VANILLA_OPTION
+    exercise = EquityTreeExerciseTypes.AMERICAN
+    option_type = OptionTypes.AMERICAN_PUT
+    params = np.array([-1.0, strike_price])
+
+    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
+                                           dividend_yield=dividend_yield, sigma=volatility,
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=strike_price, digital=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+    tree = EquityBinomialTree()
+    value = tree.value(
+        stock_price,
+        discount_curve,
+        dividend_curve,
+        volatility,
+        num_steps,
+        valuation_date,
+        payoff,
+        expiry_date,
+        payoff,
+        exercise,
+        params)  # price, delta, gamma, theta
+    assert v == approx(value[0], abs=1e-1)
+

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -76,9 +76,66 @@ def test_black_scholes_finite_difference():
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07834108133101789)
 
+    # wind=2
+    wind = 2
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == approx(0.08042112779963827)
+
     # wind=-1
     wind = -1
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.08042112779963827)
     wind = 0
+
+
+from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
+from financepy.models.black_scholes import BlackScholes
+from financepy.utils.date import Date
+from financepy.products.equity.equity_binomial_tree import EquityTreePayoffTypes
+from financepy.products.equity.equity_binomial_tree import EquityTreeExerciseTypes
+from financepy.products.equity.equity_binomial_tree import EquityBinomialTree
+import numpy as np
+
+stock_price = 50.0
+risk_free_rate = 0.06
+dividend_yield = 0.04
+volatility = 0.40
+
+valuation_date = Date(1, 1, 2016)
+expiry_date = Date(1, 1, 2021)
+model = BlackScholes(volatility)
+discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
+dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+
+num_steps = 100
+
+strike_price = 50.0
+
+
+
+def test_european_call():
+    # payoff = EquityTreePayoffTypes.VANILLA_OPTION
+    payoff = PUT_CALL.CALL.value
+    exercise = EquityTreeExerciseTypes.EUROPEAN
+    params = np.array([1.0, strike_price])
+
+    #_, v = black_scholes_finite_difference(stock_price, risk_free_rate, mu, volatility**2, expiry, strike_price, dig,
+    #                                       payoff, exercise, smooth, theta, wind,
+    #                                       num_std, num_steps, num_s, update, num_pr)
+    """
+    value = tree.value(
+        stock_price,
+        discount_curve,
+        dividend_curve,
+        volatility,
+        num_steps,
+        valuation_date,
+        payoff,
+        expiry_date,
+        payoff,
+        exercise,
+        params)
+    """
+    # assert [round(x, 4) for x in value] == [8.0175, 0.5747, 0.0187, -3.8111]  # price, delta, gamma, theta

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -25,6 +25,13 @@ def test_black_scholes_finite_difference():
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                              num_std, num_t, num_s, update, num_pr)
     assert v == 0.07939664662902503
+    
+    # smooth
+    smooth = 1
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == 0.07945913698961202
+    smooth = 0
 
     # European put
     pc = PUT_CALL.PUT.value

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -13,6 +13,13 @@ from pytest import approx
 
 
 def test_black_scholes_finite_difference():
+    """
+    Compare the output of black_schole_finite_difference to kBlack::fdRunner from
+    https://github.com/domokane/CompFin/blob/main/Week%204/xladdin/Utility/kBlack.cpp
+
+    Results are identical to 3dp. The residual is due to differences interest and
+    dividend rates determined from the discount and dividend curves.
+    """
     s0 = 1
     r = 0.04
     dividend_yield = 0.07
@@ -102,6 +109,9 @@ def test_black_scholes_finite_difference():
 
 
 def test_european_call():
+    """
+    Check finite difference method gives similar result to binomial tree
+    """
     stock_price = 50.0
     risk_free_rate = 0.06
     dividend_yield = 0.00
@@ -141,6 +151,9 @@ def test_european_call():
 
 
 def test_european_put():
+    """
+    Check finite difference method gives similar result to binomial tree
+    """
     stock_price = 50.0
     risk_free_rate = 0.06
     dividend_yield = 0.00
@@ -179,66 +192,10 @@ def test_european_put():
     assert v == approx(value[0], abs=1e-1)
 
 
-def test_call_option():
-    expiry_date = Date(1, 7, 2015)
-    strike_price = 100.0
-    option_type = OptionTypes.EUROPEAN_CALL
-    call_option = EquityVanillaOption(
-        expiry_date, strike_price, option_type)
-
-    valuation_date = Date(1, 1, 2015)
-    stock_price = 100
-    volatility = 0.30
-    interest_rate = 0.05
-    dividend_yield = 0.01
-    model = BlackScholes(volatility)
-    discount_curve = DiscountCurveFlat(valuation_date, interest_rate)
-    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
-
-    # Call option
-    v0 = call_option.value(valuation_date, stock_price,
-                           discount_curve, dividend_curve, model)
-
-    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
-                                           expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=100.0, discount_curve=discount_curve,
-                                           dividend_curve=dividend_curve, digital=0,
-                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
-    assert v == approx(v0, 1e-1)
-
-
-def test_put_option():
-    expiry_date = Date(1, 7, 2015)
-    strike_price = 100.0
-    option_type = OptionTypes.EUROPEAN_PUT
-    put_option = EquityVanillaOption(
-        expiry_date, strike_price, option_type)
-
-    valuation_date = Date(1, 1, 2015)
-    stock_price = 100
-    volatility = 0.30
-    interest_rate = 0.05
-    dividend_yield = 0.1
-    model = BlackScholes(volatility)
-    discount_curve = DiscountCurveFlat(valuation_date, interest_rate)
-    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
-
-    # Call option
-    v0 = put_option.value(valuation_date, stock_price,
-                          discount_curve, dividend_curve, model)
-
-    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
-                                           expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=100.0, discount_curve=discount_curve,
-                                           dividend_curve=dividend_curve, digital=0,
-                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
-
-    assert v == approx(v0, 1e-1)
-
-
 def test_american_call():
+    """
+    Check finite difference method gives similar result to binomial tree
+    """
     stock_price = 50.0
     risk_free_rate = 0.06
     dividend_yield = 0.05
@@ -278,6 +235,9 @@ def test_american_call():
 
 
 def test_american_put():
+    """
+    Check finite difference method gives similar result to binomial tree
+    """
     stock_price = 50.0
     risk_free_rate = 0.06
     dividend_yield = 0.05
@@ -314,3 +274,68 @@ def test_american_put():
         exercise,
         params)  # price, delta, gamma, theta
     assert v == approx(value[0], abs=1e-1)
+
+def test_call_option():
+    """
+    Check finite difference method gives similar result to BlackScholes model
+    """
+    expiry_date = Date(1, 7, 2015)
+    strike_price = 100.0
+    option_type = OptionTypes.EUROPEAN_CALL
+    call_option = EquityVanillaOption(
+        expiry_date, strike_price, option_type)
+
+    valuation_date = Date(1, 1, 2015)
+    stock_price = 100
+    volatility = 0.30
+    interest_rate = 0.05
+    dividend_yield = 0.01
+    model = BlackScholes(volatility)
+    discount_curve = DiscountCurveFlat(valuation_date, interest_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+
+    # Call option
+    v0 = call_option.value(valuation_date, stock_price,
+                           discount_curve, dividend_curve, model)
+
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=100.0, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+    assert v == approx(v0, 1e-1)
+
+
+def test_put_option():
+    """
+    Check finite difference method gives similar result to BlackScholes model
+    """
+    expiry_date = Date(1, 7, 2015)
+    strike_price = 100.0
+    option_type = OptionTypes.EUROPEAN_PUT
+    put_option = EquityVanillaOption(
+        expiry_date, strike_price, option_type)
+
+    valuation_date = Date(1, 1, 2015)
+    stock_price = 100
+    volatility = 0.30
+    interest_rate = 0.05
+    dividend_yield = 0.1
+    model = BlackScholes(volatility)
+    discount_curve = DiscountCurveFlat(valuation_date, interest_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+
+    # Call option
+    v0 = put_option.value(valuation_date, stock_price,
+                          discount_curve, dividend_curve, model)
+
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=100.0, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+
+    assert v == approx(v0, 1e-1)
+

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,6 +1,6 @@
 from pytest import approx
 
-from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, AMER_EURO
+from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, exercise_type
 from financepy.utils.global_vars import gDaysInYear
 
 def test_black_scholes_finite_difference():
@@ -14,7 +14,7 @@ def test_black_scholes_finite_difference():
     strike = 1.025
     dig = 0
     pc = PUT_CALL.CALL.value
-    ea = AMER_EURO.EURO.value
+    ea = exercise_type.EUROPEAN.value
     smooth = 0
 
     theta = 0.5
@@ -58,7 +58,7 @@ def test_black_scholes_finite_difference():
     assert v == approx(0.2139059947533305)
 
     # American put
-    ea = AMER_EURO.AMER.value
+    ea = exercise_type.AMERICAN.value
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2165916613669189)
@@ -68,7 +68,7 @@ def test_black_scholes_finite_difference():
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.10259475990431438)
-    ea = AMER_EURO.EURO.value
+    ea = exercise_type.EUROPEAN.value
 
     # wind=1
     wind = 1

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,12 +1,21 @@
+from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, exercise_type
+from financepy.utils.global_types import OptionTypes
+from financepy.products.equity.equity_vanilla_option import EquityVanillaOption
+from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
+from financepy.models.black_scholes import BlackScholes
+from financepy.utils.date import Date
+from financepy.products.equity.equity_binomial_tree import EquityTreePayoffTypes
+from financepy.products.equity.equity_binomial_tree import EquityTreeExerciseTypes
+from financepy.products.equity.equity_binomial_tree import EquityBinomialTree
+
+import numpy as np
 from pytest import approx
 
-from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, exercise_type
-from financepy.utils.global_vars import gDaysInYear
 
 def test_black_scholes_finite_difference():
     s0 = 1
     r = 0.04
-    mu = -0.03
+    dividend_yield = 0.07
     sigma = 0.2
 
     valuation_date = Date(1, 1, 2016)
@@ -26,26 +35,26 @@ def test_black_scholes_finite_difference():
     num_pr = 1
 
     # European call
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                              num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07939664662902503)
     
     # smooth
     smooth = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07945913698961202)
     smooth = 0
 
     # dig
     dig = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2153451094307548)
 
     #smooth dig
     smooth = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.22078914857802928)
     smooth = 0
@@ -53,75 +62,63 @@ def test_black_scholes_finite_difference():
 
     # European put
     pc = PUT_CALL.PUT.value
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2139059947533305)
 
     # American put
     ea = exercise_type.AMERICAN.value
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2165916613669189)
 
     # American call
     pc = PUT_CALL.CALL.value
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.10259475990431438)
     ea = exercise_type.EUROPEAN.value
 
     # wind=1
     wind = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07834108133101789)
 
     # wind=2
     wind = 2
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.08042112779963827)
 
     # wind=-1
     wind = -1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.08042112779963827)
     wind = 0
 
 
-from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
-from financepy.models.black_scholes import BlackScholes
-from financepy.utils.date import Date
-from financepy.products.equity.equity_binomial_tree import EquityTreePayoffTypes
-from financepy.products.equity.equity_binomial_tree import EquityTreeExerciseTypes
-from financepy.products.equity.equity_binomial_tree import EquityBinomialTree
-import numpy as np
-
-stock_price = 50.0
-risk_free_rate = 0.06
-dividend_yield = 0.00
-volatility = 0.40
-
-valuation_date = Date(1, 1, 2016)
-expiry_date = Date(1, 1, 2021)
-model = BlackScholes(volatility)
-discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
-dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
-num_steps = 100
-strike_price = 50.0
-
-
-
 def test_european_call():
+    stock_price = 50.0
+    risk_free_rate = 0.06
+    dividend_yield = 0.00
+    volatility = 0.40
+
+    valuation_date = Date(1, 1, 2016)
+    expiry_date = Date(1, 1, 2021)
+    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+    num_steps = 100
+    strike_price = 50.0
     payoff = EquityTreePayoffTypes.VANILLA_OPTION
     exercise = EquityTreeExerciseTypes.EUROPEAN
     params = np.array([1.0, strike_price])
 
     _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
-                                           mu=0, sigma=np.sqrt(volatility),
+                                           dividend_yield=dividend_yield, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=strike_price, dig=0,
+                                           strike_price=strike_price, digital=0,
                                            pc=PUT_CALL.CALL.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
@@ -137,17 +134,29 @@ def test_european_call():
         payoff,
         exercise,
         params)  # price, delta, gamma, theta
-    assert v == round(value[0], 4)
+    assert v == approx(value[0], abs=1e-1)
+
 
 def test_european_put():
+    stock_price = 50.0
+    risk_free_rate = 0.06
+    dividend_yield = 0.00
+    volatility = 0.40
+
+    valuation_date = Date(1, 1, 2016)
+    expiry_date = Date(1, 1, 2021)
+    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+    num_steps = 100
+    strike_price = 50.0
     payoff = EquityTreePayoffTypes.VANILLA_OPTION
     exercise = EquityTreeExerciseTypes.EUROPEAN
     params = np.array([-1.0, strike_price])
 
     _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
-                                           mu=0, sigma=np.sqrt(volatility),
+                                           dividend_yield=dividend_yield, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=strike_price, dig=0,
+                                           strike_price=strike_price, digital=0,
                                            pc=PUT_CALL.PUT.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
@@ -163,5 +172,64 @@ def test_european_put():
         payoff,
         exercise,
         params)  # price, delta, gamma, theta
-    assert v == round(value[0], 4)
+    assert v == approx(value[0], abs=1e-1)
 
+
+def test_call_option():
+    expiry_date = Date(1, 7, 2015)
+    strike_price = 100.0
+    call_option = EquityVanillaOption(
+        expiry_date, strike_price, OptionTypes.EUROPEAN_CALL)
+
+    valuation_date = Date(1, 1, 2015)
+    stock_price = 100
+    volatility = 0.30
+    interest_rate = 0.05
+    dividend_yield = 0.01
+    model = BlackScholes(volatility)
+    discount_curve = DiscountCurveFlat(valuation_date, interest_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+
+    # Call option
+    v0 = call_option.value(valuation_date, stock_price,
+                          discount_curve, dividend_curve, model)
+
+
+    exercise = EquityTreeExerciseTypes.EUROPEAN
+    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=interest_rate,
+                                           dividend_yield=dividend_yield, sigma=volatility,
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=100.0, digital=0,
+                                           pc=PUT_CALL.CALL.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+    assert v == approx(v0, 1e-1)
+
+
+def test_put_option():
+    expiry_date = Date(1, 7, 2015)
+    strike_price = 100.0
+    put_option = EquityVanillaOption(
+        expiry_date, strike_price, OptionTypes.EUROPEAN_PUT)
+
+    valuation_date = Date(1, 1, 2015)
+    stock_price = 100
+    volatility = 0.30
+    interest_rate = 0.05
+    dividend_yield = 0.1
+    model = BlackScholes(volatility)
+    discount_curve = DiscountCurveFlat(valuation_date, interest_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+
+    # Call option
+    v0 = put_option.value(valuation_date, stock_price,
+                           discount_curve, dividend_curve, model)
+
+    exercise = EquityTreeExerciseTypes.EUROPEAN
+    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=interest_rate,
+                                           dividend_yield=dividend_yield, sigma=volatility,
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=100.0, digital=0,
+                                           pc=PUT_CALL.PUT.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+
+    assert v == approx(v0, 1e-1)

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -33,6 +33,20 @@ def test_black_scholes_finite_difference():
     assert v == 0.07945913698961202
     smooth = 0
 
+    # dig
+    dig = 1
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == 0.2153451094307548
+
+    #smooth dig
+    smooth = 1
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == 0.22078914857802928
+    smooth = 0
+    dig = 0
+
     # European put
     pc = PUT_CALL.PUT.value
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -73,4 +73,10 @@ def test_black_scholes_finite_difference():
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07834108133101789)
+
+    # wind=-1
+    wind = -1
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == approx(0.08042112779963827)
     wind = 0

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -66,3 +66,11 @@ def test_black_scholes_finite_difference():
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.10259475990431438)
+    ea = AMER_EURO.EURO.value
+
+    # wind=1
+    wind = 1
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == approx(0.07834108133101789)
+    wind = 0

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -20,6 +20,8 @@ def test_black_scholes_finite_difference():
 
     valuation_date = Date(1, 1, 2016)
     expiry_date = Date(30, 12, 2020)
+    discount_curve = DiscountCurveFlat(valuation_date, r)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
     strike = 1.025
     dig = 0
     smooth = 0
@@ -33,59 +35,69 @@ def test_black_scholes_finite_difference():
     num_pr = 1
 
     option_type = OptionTypes.EUROPEAN_CALL
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
-                                             num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.07939664662902503)
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == approx(0.07939664662902503, abs=1e-3)
     
     smooth = True
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.07945913698961202)
+    assert v == approx(0.07945913698961202, abs=1e-3)
     smooth = 0
 
     dig = 1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.2153451094307548)
+    assert v == approx(0.2153451094307548, abs=1e-3)
 
     #smooth dig
     smooth = 1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.22078914857802928)
+    assert v == approx(0.22078914857802928, abs=1e-3)
     smooth = 0
     dig = 0
 
     option_type = OptionTypes.EUROPEAN_PUT
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.2139059947533305)
+    assert v == approx(0.2139059947533305, abs=1e-3)
 
     option_type = OptionTypes.AMERICAN_PUT
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.2165916613669189)
+    assert v == approx(0.2165916613669189, abs=1e-3)
 
     option_type = OptionTypes.AMERICAN_CALL
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.10259475990431438)
+    assert v == approx(0.10259475990431438, abs=1e-3)
     option_type = OptionTypes.EUROPEAN_CALL
 
     wind = 1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.07834108133101789)
+    assert v == approx(0.07834108133101789, abs=1e-3)
 
     wind = 2
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.08042112779963827)
+    assert v == approx(0.08042112779963827, abs=1e-3)
 
     wind = -1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
+                                           dividend_curve, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == approx(0.08042112779963827)
+    assert v == approx(0.08042112779963827, abs=1e-3)
     wind = 0
 
 
@@ -106,10 +118,10 @@ def test_european_call():
     option_type = OptionTypes.EUROPEAN_CALL
     params = np.array([1.0, strike_price])
 
-    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
-                                           dividend_yield=dividend_yield, sigma=volatility,
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=strike_price, digital=0,
+                                           strike_price=strike_price, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
@@ -145,10 +157,10 @@ def test_european_put():
     option_type = OptionTypes.EUROPEAN_PUT
     params = np.array([-1.0, strike_price])
 
-    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
-                                           dividend_yield=dividend_yield, sigma=volatility,
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=strike_price, digital=0,
+                                           strike_price=strike_price, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
@@ -187,10 +199,10 @@ def test_call_option():
     v0 = call_option.value(valuation_date, stock_price,
                            discount_curve, dividend_curve, model)
 
-    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=interest_rate,
-                                           dividend_yield=dividend_yield, sigma=volatility,
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=100.0, digital=0,
+                                           strike_price=100.0, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     assert v == approx(v0, 1e-1)
@@ -216,14 +228,15 @@ def test_put_option():
     v0 = put_option.value(valuation_date, stock_price,
                           discount_curve, dividend_curve, model)
 
-    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=interest_rate,
-                                           dividend_yield=dividend_yield, sigma=volatility,
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=100.0, digital=0,
+                                           strike_price=100.0, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
 
     assert v == approx(v0, 1e-1)
+
 
 def test_american_call():
     stock_price = 50.0
@@ -242,10 +255,10 @@ def test_american_call():
     option_type = OptionTypes.AMERICAN_CALL
     params = np.array([1.0, strike_price])
 
-    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
-                                           dividend_yield=dividend_yield, sigma=volatility,
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=strike_price, digital=0,
+                                           strike_price=strike_price, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
@@ -281,10 +294,10 @@ def test_american_put():
     option_type = OptionTypes.AMERICAN_PUT
     params = np.array([-1.0, strike_price])
 
-    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
-                                           dividend_yield=dividend_yield, sigma=volatility,
+    _, v = black_scholes_finite_difference(stock_price=stock_price, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
-                                           strike_price=strike_price, digital=0,
+                                           strike_price=strike_price, discount_curve=discount_curve,
+                                           dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
@@ -301,4 +314,3 @@ def test_american_put():
         exercise,
         params)  # price, delta, gamma, theta
     assert v == approx(value[0], abs=1e-1)
-

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,3 +1,5 @@
+from pytest import approx
+
 from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, AMER_EURO
 
 def test_black_scholes_finite_difference():
@@ -24,26 +26,26 @@ def test_black_scholes_finite_difference():
     # European call
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                              num_std, num_t, num_s, update, num_pr)
-    assert v == 0.07939664662902503
+    assert v == approx(0.07939664662902503)
     
     # smooth
     smooth = 1
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == 0.07945913698961202
+    assert v == approx(0.07945913698961202)
     smooth = 0
 
     # dig
     dig = 1
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == 0.2153451094307548
+    assert v == approx(0.2153451094307548)
 
     #smooth dig
     smooth = 1
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == 0.22078914857802928
+    assert v == approx(0.22078914857802928)
     smooth = 0
     dig = 0
 
@@ -51,16 +53,16 @@ def test_black_scholes_finite_difference():
     pc = PUT_CALL.PUT.value
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == 0.2139059947533305
+    assert v == approx(0.2139059947533305)
 
     # American put
     ea = AMER_EURO.AMER.value
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == 0.2165916613669189
+    assert v == approx(0.2165916613669189)
 
     # American call
     pc = PUT_CALL.CALL.value
     _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
-    assert v == 0.10259475990431438
+    assert v == approx(0.10259475990431438)

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,6 +1,7 @@
 from pytest import approx
 
 from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, AMER_EURO
+from financepy.utils.global_vars import gDaysInYear
 
 def test_black_scholes_finite_difference():
     s0 = 1
@@ -8,7 +9,8 @@ def test_black_scholes_finite_difference():
     mu = -0.03
     sigma = 0.2
 
-    expiry = 5
+    valuation_date = Date(1, 1, 2016)
+    expiry_date = Date(30, 12, 2020)
     strike = 1.025
     dig = 0
     pc = PUT_CALL.CALL.value
@@ -24,26 +26,26 @@ def test_black_scholes_finite_difference():
     num_pr = 1
 
     # European call
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                              num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07939664662902503)
     
     # smooth
     smooth = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07945913698961202)
     smooth = 0
 
     # dig
     dig = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2153451094307548)
 
     #smooth dig
     smooth = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.22078914857802928)
     smooth = 0
@@ -51,32 +53,32 @@ def test_black_scholes_finite_difference():
 
     # European put
     pc = PUT_CALL.PUT.value
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2139059947533305)
 
     # American put
     ea = AMER_EURO.AMER.value
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2165916613669189)
 
     # American call
     pc = PUT_CALL.CALL.value
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.10259475990431438)
     ea = AMER_EURO.EURO.value
 
     # wind=1
     wind = 1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07834108133101789)
 
     # wind=-1
     wind = -1
-    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.08042112779963827)
     wind = 0

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,4 +1,5 @@
-from financepy.models.finite_difference import black_scholes_finite_difference, dx, dxx, solve_tridiagonal_matrix
+from financepy.models.finite_difference import (
+    black_scholes_finite_difference, dx, dxx, solve_tridiagonal_matrix, band_matrix_multiplication)
 from financepy.utils.global_types import OptionTypes
 from financepy.products.equity.equity_vanilla_option import EquityVanillaOption
 from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
@@ -364,6 +365,7 @@ def test_dxx():
                                             [4., -8.,  4.],
                                             [0.,  0.,  0.]]))
 
+
 def test_solve_tridiagonal_matrix():
     M = np.array([
         [0, 1, 1, 1],
@@ -375,3 +377,13 @@ def test_solve_tridiagonal_matrix():
     u = solve_tridiagonal_matrix(M, r)
 
     np.testing.assert_array_equal(u, np.array([-0.08, -0.12, -0.12, -0.08]))
+
+
+def test_band_matrix_multiplication():
+    M = np.array([
+        [0, 1, 1, 1],
+        [-2, -2, -2, -2],
+        [1, 1, 1, 0]]
+    ).T
+    u = np.array([-0.08, -0.12, -0.12, -0.08])
+    np.testing.assert_array_almost_equal(band_matrix_multiplication(M, 1, 1, u), np.array([0.04] * 4))

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -39,32 +39,31 @@ def test_black_scholes_finite_difference():
     num_t = 50
     num_s = 200
     update = 0
-    num_pr = 1
 
     option_type = OptionTypes.EUROPEAN_CALL
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.07939664662902503, abs=1e-3)
     
     smooth = True
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.07945913698961202, abs=1e-3)
     smooth = 0
 
     dig = 1
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.2153451094307548, abs=1e-3)
 
     #smooth dig
     smooth = 1
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.22078914857802928, abs=1e-3)
     smooth = 0
     dig = 0
@@ -72,38 +71,38 @@ def test_black_scholes_finite_difference():
     option_type = OptionTypes.EUROPEAN_PUT
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.2139059947533305, abs=1e-3)
 
     option_type = OptionTypes.AMERICAN_PUT
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.2165916613669189, abs=1e-3)
 
     option_type = OptionTypes.AMERICAN_CALL
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.10259475990431438, abs=1e-3)
     option_type = OptionTypes.EUROPEAN_CALL
 
     wind = 1
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.07834108133101789, abs=1e-3)
 
     wind = 2
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.08042112779963827, abs=1e-3)
 
     wind = -1
     _, v = black_scholes_finite_difference(s0, sigma, expiry_date, valuation_date, strike, discount_curve,
                                            dividend_curve, dig, option_type, smooth, theta, wind,
-                                           num_std, num_t, num_s, update, num_pr)
+                                           num_std, num_t, num_s, update)
     assert v == approx(0.08042112779963827, abs=1e-3)
     wind = 0
 
@@ -133,7 +132,7 @@ def test_european_call():
                                            strike_price=strike_price, discount_curve=discount_curve,
                                            dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+                                           num_std=5, num_steps=50, num_samples=200, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         stock_price,
@@ -175,7 +174,7 @@ def test_european_put():
                                            strike_price=strike_price, discount_curve=discount_curve,
                                            dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+                                           num_std=5, num_steps=50, num_samples=200, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         stock_price,
@@ -217,7 +216,7 @@ def test_american_call():
                                            strike_price=strike_price, discount_curve=discount_curve,
                                            dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+                                           num_std=5, num_steps=50, num_samples=200, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         stock_price,
@@ -259,7 +258,7 @@ def test_american_put():
                                            strike_price=strike_price, discount_curve=discount_curve,
                                            dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+                                           num_std=5, num_steps=50, num_samples=200, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         stock_price,
@@ -303,7 +302,7 @@ def test_call_option():
                                            strike_price=100.0, discount_curve=discount_curve,
                                            dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+                                           num_std=5, num_steps=50, num_samples=200, update=False)
     assert v == approx(v0, 1e-1)
 
 
@@ -335,7 +334,7 @@ def test_put_option():
                                            strike_price=100.0, discount_curve=discount_curve,
                                            dividend_curve=dividend_curve, digital=0,
                                            option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+                                           num_std=5, num_steps=50, num_samples=200, update=False)
 
     assert v == approx(v0, 1e-1)
 

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -100,7 +100,7 @@ import numpy as np
 
 stock_price = 50.0
 risk_free_rate = 0.06
-dividend_yield = 0.04
+dividend_yield = 0.00
 volatility = 0.40
 
 valuation_date = Date(1, 1, 2016)
@@ -108,23 +108,23 @@ expiry_date = Date(1, 1, 2021)
 model = BlackScholes(volatility)
 discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
 dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
-
 num_steps = 100
-
 strike_price = 50.0
 
 
 
 def test_european_call():
-    # payoff = EquityTreePayoffTypes.VANILLA_OPTION
-    payoff = PUT_CALL.CALL.value
+    payoff = EquityTreePayoffTypes.VANILLA_OPTION
     exercise = EquityTreeExerciseTypes.EUROPEAN
     params = np.array([1.0, strike_price])
 
-    #_, v = black_scholes_finite_difference(stock_price, risk_free_rate, mu, volatility**2, expiry, strike_price, dig,
-    #                                       payoff, exercise, smooth, theta, wind,
-    #                                       num_std, num_steps, num_s, update, num_pr)
-    """
+    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
+                                           mu=0, sigma=np.sqrt(volatility),
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=strike_price, dig=0,
+                                           pc=PUT_CALL.CALL.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+    tree = EquityBinomialTree()
     value = tree.value(
         stock_price,
         discount_curve,
@@ -136,6 +136,32 @@ def test_european_call():
         expiry_date,
         payoff,
         exercise,
-        params)
-    """
-    # assert [round(x, 4) for x in value] == [8.0175, 0.5747, 0.0187, -3.8111]  # price, delta, gamma, theta
+        params)  # price, delta, gamma, theta
+    assert v == round(value[0], 4)
+
+def test_european_put():
+    payoff = EquityTreePayoffTypes.VANILLA_OPTION
+    exercise = EquityTreeExerciseTypes.EUROPEAN
+    params = np.array([-1.0, strike_price])
+
+    _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
+                                           mu=0, sigma=np.sqrt(volatility),
+                                           expiry_date=expiry_date, valuation_date=valuation_date,
+                                           strike_price=strike_price, dig=0,
+                                           pc=PUT_CALL.PUT.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
+    tree = EquityBinomialTree()
+    value = tree.value(
+        stock_price,
+        discount_curve,
+        dividend_curve,
+        volatility,
+        num_steps,
+        valuation_date,
+        payoff,
+        expiry_date,
+        payoff,
+        exercise,
+        params)  # price, delta, gamma, theta
+    assert v == round(value[0], 4)
+

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,0 +1,45 @@
+from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, AMER_EURO
+
+def test_black_scholes_finite_difference():
+    s0 = 1
+    r = 0.04
+    mu = -0.03
+    sigma = 0.2
+
+    expiry = 5
+    strike = 1.025
+    dig = 0
+    pc = PUT_CALL.CALL.value
+    ea = AMER_EURO.EURO.value
+    smooth = 0
+
+    theta = 0.5
+    wind = 0
+    num_std = 5
+    num_t = 50
+    num_s = 200
+    update = 0
+    num_pr = 1
+
+    # European call
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                             num_std, num_t, num_s, update, num_pr)
+    assert v == 0.07939664662902503
+
+    # European put
+    pc = PUT_CALL.PUT.value
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == 0.2139059947533305
+
+    # American put
+    ea = AMER_EURO.AMER.value
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == 0.2165916613669189
+
+    # American call
+    pc = PUT_CALL.CALL.value
+    _, v = black_scholes_finite_difference(s0, r, mu, sigma, expiry, strike, dig, pc, ea, smooth, theta, wind,
+                                           num_std, num_t, num_s, update, num_pr)
+    assert v == 0.10259475990431438

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,4 +1,4 @@
-from financepy.models.finite_difference import black_scholes_finite_difference, PUT_CALL, exercise_type
+from financepy.models.finite_difference import black_scholes_finite_difference
 from financepy.utils.global_types import OptionTypes
 from financepy.products.equity.equity_vanilla_option import EquityVanillaOption
 from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
@@ -22,8 +22,6 @@ def test_black_scholes_finite_difference():
     expiry_date = Date(30, 12, 2020)
     strike = 1.025
     dig = 0
-    pc = PUT_CALL.CALL.value
-    ea = exercise_type.EUROPEAN.value
     smooth = 0
 
     theta = 0.5
@@ -34,66 +32,58 @@ def test_black_scholes_finite_difference():
     update = 0
     num_pr = 1
 
-    # European call
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    option_type = OptionTypes.EUROPEAN_CALL
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                              num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07939664662902503)
     
-    # smooth
-    smooth = 1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    smooth = True
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07945913698961202)
     smooth = 0
 
-    # dig
     dig = 1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2153451094307548)
 
     #smooth dig
     smooth = 1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.22078914857802928)
     smooth = 0
     dig = 0
 
-    # European put
-    pc = PUT_CALL.PUT.value
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    option_type = OptionTypes.EUROPEAN_PUT
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2139059947533305)
 
-    # American put
-    ea = exercise_type.AMERICAN.value
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    option_type = OptionTypes.AMERICAN_PUT
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.2165916613669189)
 
-    # American call
-    pc = PUT_CALL.CALL.value
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    option_type = OptionTypes.AMERICAN_CALL
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.10259475990431438)
-    ea = exercise_type.EUROPEAN.value
+    option_type = OptionTypes.EUROPEAN_CALL
 
-    # wind=1
     wind = 1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.07834108133101789)
 
-    # wind=2
     wind = 2
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.08042112779963827)
 
-    # wind=-1
     wind = -1
-    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, pc, ea, smooth, theta, wind,
+    _, v = black_scholes_finite_difference(s0, r, dividend_yield, sigma, expiry_date, valuation_date, strike, dig, option_type, smooth, theta, wind,
                                            num_std, num_t, num_s, update, num_pr)
     assert v == approx(0.08042112779963827)
     wind = 0
@@ -113,13 +103,14 @@ def test_european_call():
     strike_price = 50.0
     payoff = EquityTreePayoffTypes.VANILLA_OPTION
     exercise = EquityTreeExerciseTypes.EUROPEAN
+    option_type = OptionTypes.EUROPEAN_CALL
     params = np.array([1.0, strike_price])
 
     _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
                                            dividend_yield=dividend_yield, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
                                            strike_price=strike_price, digital=0,
-                                           pc=PUT_CALL.CALL.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
     value = tree.value(
@@ -151,13 +142,14 @@ def test_european_put():
     strike_price = 50.0
     payoff = EquityTreePayoffTypes.VANILLA_OPTION
     exercise = EquityTreeExerciseTypes.EUROPEAN
+    option_type = OptionTypes.EUROPEAN_PUT
     params = np.array([-1.0, strike_price])
 
     _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=risk_free_rate,
                                            dividend_yield=dividend_yield, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
                                            strike_price=strike_price, digital=0,
-                                           pc=PUT_CALL.PUT.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     tree = EquityBinomialTree()
     value = tree.value(
@@ -178,8 +170,9 @@ def test_european_put():
 def test_call_option():
     expiry_date = Date(1, 7, 2015)
     strike_price = 100.0
+    option_type = OptionTypes.EUROPEAN_CALL
     call_option = EquityVanillaOption(
-        expiry_date, strike_price, OptionTypes.EUROPEAN_CALL)
+        expiry_date, strike_price, option_type)
 
     valuation_date = Date(1, 1, 2015)
     stock_price = 100
@@ -192,15 +185,13 @@ def test_call_option():
 
     # Call option
     v0 = call_option.value(valuation_date, stock_price,
-                          discount_curve, dividend_curve, model)
+                           discount_curve, dividend_curve, model)
 
-
-    exercise = EquityTreeExerciseTypes.EUROPEAN
     _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=interest_rate,
                                            dividend_yield=dividend_yield, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
                                            strike_price=100.0, digital=0,
-                                           pc=PUT_CALL.CALL.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
     assert v == approx(v0, 1e-1)
 
@@ -208,8 +199,9 @@ def test_call_option():
 def test_put_option():
     expiry_date = Date(1, 7, 2015)
     strike_price = 100.0
+    option_type = OptionTypes.EUROPEAN_PUT
     put_option = EquityVanillaOption(
-        expiry_date, strike_price, OptionTypes.EUROPEAN_PUT)
+        expiry_date, strike_price, option_type)
 
     valuation_date = Date(1, 1, 2015)
     stock_price = 100
@@ -222,14 +214,13 @@ def test_put_option():
 
     # Call option
     v0 = put_option.value(valuation_date, stock_price,
-                           discount_curve, dividend_curve, model)
+                          discount_curve, dividend_curve, model)
 
-    exercise = EquityTreeExerciseTypes.EUROPEAN
     _, v = black_scholes_finite_difference(stock_price=stock_price, risk_free_rate=interest_rate,
                                            dividend_yield=dividend_yield, sigma=volatility,
                                            expiry_date=expiry_date, valuation_date=valuation_date,
                                            strike_price=100.0, digital=0,
-                                           pc=PUT_CALL.PUT.value, exercise=exercise, smooth=0, theta=0.5, wind=0,
+                                           option_type=option_type, smooth=0, theta=0.5, wind=0,
                                            num_std=5, num_steps=50, num_samples=200, update=False, num_pr=1)
 
     assert v == approx(v0, 1e-1)


### PR DESCRIPTION
This PR adds a finite difference method for option pricing.

- It is mostly based on the kBlack::fd_runner method here https://github.com/domokane/CompFin/blob/main/Week%204/xladdin/Utility/kBlack.cpp
Main differences are that I've tried to decouple some of the methods (in particular, updating the finite difference matrix and rolling backwards/forwards are now handled separately) and I didn't make my code object oriented
- Tests compare the output of this model to those in the C++ code linked above, as well as to other models in FinancePy. I've left in the comparisons between different models, but it might be better to just compare to a value if we trust the finite difference model now (the models only agree to 1dp, not sure how similar we expect them to be)
- I think I've put things in logical places in the code, but happy to move things around
- I used numba where it sped up the code, but don't have too much experience with it so it could maybe have been done better
- I'm new to finance, so sorry if any comments/function names/variable names have used the wrong terminology!