### PR TITLE
Use numba for band matrix multiplication

### DIFF
--- a/financepy/utils/math.py
+++ b/financepy/utils/math.py
@@ -666,6 +666,7 @@ def npv(irr: float, times_cfs: list):
     return _npv
 
 
+@njit(fastmath=True, cache=True)
 def band_matrix_multiplication(A, m1, m2, b):
     n = A.shape[0]
     x = np.zeros(n)
@@ -677,9 +678,9 @@ def band_matrix_multiplication(A, m1, m2, b):
     ju[ju > n - 1] = n - 1
 
     for i in range(n):
-        j = np.arange(jl[i], ju[i] + 1)
-        k = j - i + m1
-        x[i] += np.sum(A[i, k] * b[j])
+        for j in range(jl[i], ju[i] + 1):
+            k = j - i + m1
+            x[i] += A[i, k] * b[j]
 
     return x
 

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -152,7 +152,7 @@ def test_european_call():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=50, num_samples=200, update=False)
+                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -195,7 +195,7 @@ def test_european_put():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=50, num_samples=200, update=False)
+                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -238,7 +238,7 @@ def test_american_call():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=50, num_samples=200, update=False)
+                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -281,7 +281,7 @@ def test_american_put():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=50, num_samples=200, update=False)
+                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -327,8 +327,8 @@ def test_call_option():
                                         strike_price=100.0, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=50, num_samples=200, update=False)
-    assert v == approx(v0, 1e-1)
+                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
+    assert v == approx(v0, 1e-5)
 
 
 def test_put_option():
@@ -360,9 +360,9 @@ def test_put_option():
                                         strike_price=100.0, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=50, num_samples=200, update=False)
+                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
 
-    assert v == approx(v0, 1e-1)
+    assert v == approx(v0, 1e-5)
 
 
 def test_dx():


### PR DESCRIPTION
Small change makes finite difference model (and the new PSOR model) about 100x faster. This allows us to use more samples, and now the tests that compare to the analytic black scholes answers match to 1e-5 accuracy