### PR TITLE
Finite difference improvements

### DIFF
--- a/financepy/models/black_scholes.py
+++ b/financepy/models/black_scholes.py
@@ -111,7 +111,6 @@ class BlackScholes(Model):
                                                     dividend_yield=dividendRate,
                                                     volatility=self._volatility,
                                                     option_type=option_type.value,
-                                                    num_steps_per_year=self._num_steps_per_year,
                                                     **self._params
                                                     )
                 return v
@@ -200,7 +199,6 @@ class BlackScholes(Model):
                                                     dividend_yield=dividendRate,
                                                     volatility=self._volatility,
                                                     option_type=option_type.value,
-                                                    num_steps_per_year=self._num_steps_per_year,
                                                     **self._params
                                                     )
                 return v

--- a/financepy/models/finite_difference.py
+++ b/financepy/models/finite_difference.py
@@ -115,8 +115,10 @@ def calculate_fd_matrix(x, r, mu, var, dt, theta, wind=0):
     return A
 
 
-def fd_roll_backwards(res, theta, Ai=np.array([]), Ae=np.array([])):
+def fd_roll_backwards(res, theta, Ai=None, Ae=None):
     # TODO Test for more than one vector
+    Ai = np.array([]) if Ai is None else Ai
+    Ae = np.array([]) if Ae is None else Ae
     num_vectors = len(res)
     mm = 1
 
@@ -133,7 +135,9 @@ def fd_roll_backwards(res, theta, Ai=np.array([]), Ae=np.array([])):
     return res
 
 
-def fd_roll_forwards(res, theta, Ai=np.array([]), Ae=np.array([])):
+def fd_roll_forwards(res, theta, Ai=None, Ae=None):
+    Ai = np.array([]) if Ai is None else Ai
+    Ae = np.array([]) if Ae is None else Ae
     num_vectors = len(res)
     mm = num_vectors // 2  # integer division
 
@@ -212,7 +216,7 @@ def option_payoff(s, strike, smooth, dig, option_type):
 
 def black_scholes_finite_difference(spot_price, volatility, time_to_expiry,
                                     strike_price, risk_free_rate, dividend_yield, option_type,
-                                    num_steps_per_year, num_samples, num_std=5, theta=0.5, wind=0, digital=False,
+                                    num_time_steps=None, num_samples=2000, num_std=5, theta=0.5, wind=0, digital=False,
                                     smooth=False, update=False):
     if isinstance(option_type, OptionTypes):
         option_type = option_type.value
@@ -234,7 +238,7 @@ def black_scholes_finite_difference(spot_price, volatility, time_to_expiry,
     payoff = option_payoff(s, strike_price, smooth, digital, option_type)
 
     # time steps
-    num_steps = int(num_steps_per_year * time_to_expiry)
+    num_steps = num_time_steps or num_samples // 2
     dt = time_to_expiry / max(1, num_steps)
 
     # Make time series for interest rate, drift, and variance

--- a/financepy/models/finite_difference_PSOR.py
+++ b/financepy/models/finite_difference_PSOR.py
@@ -45,7 +45,7 @@ def black_scholes_fd_PSOR(spot_price, volatility, time_to_expiry,
         option_type = option_type.value
 
     # Set default values
-    s_max = s_max or max(strike_price, spot_price) * 4
+    s_max = s_max or max(strike_price, spot_price) * 10
     num_samples = num_samples or s_max * 10
     num_steps = num_steps or int(num_samples // 2)
 

--- a/notebooks/models/FINITE_DIFFERENCE.ipynb
+++ b/notebooks/models/FINITE_DIFFERENCE.ipynb
@@ -69,8 +69,7 @@
     "risk_free_rate = 0.05\n",
     "dividend_yield = 0.01\n",
     "num_std = 5\n",
-    "num_samples = 200\n",
-    "num_steps = 50\n",
+    "num_samples = 20000\n",
     "\n",
     "# Time to contract expiry in years\n",
     "time_to_expiry = (expiry_date - valuation_date) / gDaysInYear\n"
@@ -88,7 +87,7 @@
     "                                    strike_price=100.0, risk_free_rate=risk_free_rate,\n",
     "                                    dividend_yield=dividend_yield, digital=0,\n",
     "                                    option_type=option_type, smooth=0, theta=0.5, wind=0,\n",
-    "                                    num_std=num_std, num_steps_per_year=num_steps, num_samples=num_samples,\n",
+    "                                    num_std=num_std, num_time_steps=None, num_samples=num_samples,\n",
     "                                    update=False)"
    ]
   },
@@ -102,7 +101,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Option value is $9.29\n"
+      "Option value is $9.30\n"
      ]
     }
    ],

--- a/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
+++ b/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
@@ -424,7 +424,7 @@
     {
      "data": {
       "text/plain": [
-       "3.427658146941697"
+       "3.4276581469416914"
       ]
      },
      "execution_count": 20,
@@ -451,7 +451,7 @@
     {
      "data": {
       "text/plain": [
-       "3.427658146941697"
+       "3.4276581469416914"
       ]
      },
      "execution_count": 21,
@@ -477,7 +477,7 @@
    "outputs": [],
    "source": [
     "params = {\n",
-    "    'num_samples': 200,\n",
+    "    'num_samples': 2000,\n",
     "    'theta': 0.5\n",
     "}\n",
     "model = BlackScholes(volatility,\n",
@@ -493,7 +493,7 @@
     {
      "data": {
       "text/plain": [
-       "3.427658146941697"
+       "3.4276581469416914"
       ]
      },
      "execution_count": 23,
@@ -513,7 +513,7 @@
     {
      "data": {
       "text/plain": [
-       "3.4280954904358447"
+       "3.4276540933598305"
       ]
      },
      "execution_count": 24,
@@ -533,7 +533,7 @@
     {
      "data": {
       "text/plain": [
-       "3.4280954904358447"
+       "3.4276540933598305"
       ]
      },
      "execution_count": 25,
@@ -553,7 +553,7 @@
     {
      "data": {
       "text/plain": [
-       "2.2031750852278353"
+       "2.2031750852278296"
       ]
      },
      "execution_count": 26,
@@ -573,7 +573,7 @@
     {
      "data": {
       "text/plain": [
-       "2.203612329591362"
+       "2.2031710315837243"
       ]
      },
      "execution_count": 27,
@@ -595,7 +595,7 @@
     {
      "data": {
       "text/plain": [
-       "2.3153118888927473"
+       "2.319903905249911"
       ]
      },
      "execution_count": 28,
@@ -622,6 +622,7 @@
    "source": [
     "params = {\n",
     "    'theta': 0.5,\n",
+    "    'num_samples': 2000,\n",
     "    'delta_bound': 1e-5,\n",
     "    'omega': 0.5\n",
     "}\n",
@@ -638,7 +639,7 @@
     {
      "data": {
       "text/plain": [
-       "3.427658146941697"
+       "3.4276581469416914"
       ]
      },
      "execution_count": 30,
@@ -658,7 +659,7 @@
     {
      "data": {
       "text/plain": [
-       "3.4275929231736493"
+       "3.4275929231736475"
       ]
      },
      "execution_count": 31,
@@ -678,7 +679,7 @@
     {
      "data": {
       "text/plain": [
-       "3.4275929231736493"
+       "3.4275929231736475"
       ]
      },
      "execution_count": 32,
@@ -698,7 +699,7 @@
     {
      "data": {
       "text/plain": [
-       "2.2031750852278353"
+       "2.2031750852278296"
       ]
      },
      "execution_count": 33,
@@ -740,7 +741,7 @@
     {
      "data": {
       "text/plain": [
-       "2.319833042769567"
+       "2.3198330427695675"
       ]
      },
      "execution_count": 35,
@@ -772,6 +773,46 @@
   {
    "cell_type": "code",
    "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276581469416914"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.427145909428062"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.839882Z",
@@ -787,7 +828,7 @@
        "3.427145909428062"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -798,16 +839,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2.2031750852278353"
+       "2.2031750852278296"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -818,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -827,7 +868,7 @@
        "2.2026628477140777"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -845,7 +886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -854,7 +895,7 @@
        "2.3227588252294726"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -886,7 +927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -895,7 +936,7 @@
        "0.6240485077846358"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -906,7 +947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -915,7 +956,7 @@
        "534.1064689190489"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -926,7 +967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -935,7 +976,7 @@
        "-4.0724784861637575"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -946,7 +987,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -955,7 +996,7 @@
        "13.096682231981127"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -44,7 +44,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.07939664662902503, abs=1e-3)
 
     smooth = True
@@ -52,7 +52,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.07945913698961202, abs=1e-3)
     smooth = 0
 
@@ -61,7 +61,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.2153451094307548, abs=1e-3)
 
     #smooth dig
@@ -70,7 +70,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.22078914857802928, abs=1e-3)
     smooth = 0
     dig = 0
@@ -80,7 +80,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.2139059947533305, abs=1e-3)
 
     option_type = OptionTypes.AMERICAN_PUT
@@ -88,7 +88,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.2165916613669189, abs=1e-3)
 
     option_type = OptionTypes.AMERICAN_CALL
@@ -96,7 +96,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.10259475990431438, abs=1e-3)
     option_type = OptionTypes.EUROPEAN_CALL
 
@@ -105,7 +105,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.07834108133101789, abs=1e-3)
 
     wind = 2
@@ -113,7 +113,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.08042112779963827, abs=1e-3)
 
     wind = -1
@@ -121,7 +121,7 @@ def test_black_scholes_finite_difference():
                                         strike_price=strike, risk_free_rate=r,
                                         dividend_yield=dividend_yield, digital=dig, option_type=option_type,
                                         smooth=smooth, theta=theta, wind=wind,
-                                        num_std=num_std, num_steps_per_year=num_t, num_samples=num_s, update=update)
+                                        num_std=num_std, num_time_steps=num_t, num_samples=num_s, update=update)
     assert v == approx(0.08042112779963827, abs=1e-3)
     wind = 0
 
@@ -152,7 +152,7 @@ def test_european_call():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
+                                        num_std=5, num_time_steps=5000, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -195,7 +195,7 @@ def test_european_put():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
+                                        num_std=5, num_time_steps=2500, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -238,7 +238,7 @@ def test_american_call():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
+                                        num_std=5, num_time_steps=2500, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -281,7 +281,7 @@ def test_american_put():
                                         strike_price=strike_price, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
+                                        num_std=5, num_time_steps=2500, num_samples=10000, update=False)
     tree = EquityBinomialTree()
     value = tree.value(
         spot_price,
@@ -327,7 +327,7 @@ def test_call_option():
                                         strike_price=100.0, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
+                                        num_std=5, num_time_steps=2500, num_samples=10000, update=False)
     assert v == approx(v0, 1e-5)
 
 
@@ -360,7 +360,7 @@ def test_put_option():
                                         strike_price=100.0, risk_free_rate=risk_free_rate,
                                         dividend_yield=dividend_yield, digital=0,
                                         option_type=option_type, smooth=0, theta=0.5, wind=0,
-                                        num_std=5, num_steps_per_year=2500, num_samples=10000, update=False)
+                                        num_std=5, num_time_steps=2500, num_samples=10000, update=False)
 
     assert v == approx(v0, 1e-5)
 

--- a/tests/test_finite_difference_PSOR.py
+++ b/tests/test_finite_difference_PSOR.py
@@ -4,12 +4,9 @@ from financepy.products.equity.equity_vanilla_option import EquityVanillaOption
 from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
 from financepy.models.black_scholes import BlackScholes
 from financepy.utils.date import Date
-from financepy.products.equity.equity_binomial_tree import EquityTreePayoffTypes
-from financepy.products.equity.equity_binomial_tree import EquityTreeExerciseTypes
-from financepy.products.equity.equity_binomial_tree import EquityBinomialTree
 from financepy.utils.global_vars import gDaysInYear
+from financepy.models.equity_crr_tree import crr_tree_val_avg
 
-import numpy as np
 from pytest import approx
 
 
@@ -108,35 +105,26 @@ def test_european_call():
     valuation_date = Date(1, 1, 2016)
     expiry_date = Date(1, 1, 2021)
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
-    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
-    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
     strike_price = 50.0
-    payoff = EquityTreePayoffTypes.VANILLA_OPTION
-    exercise = EquityTreeExerciseTypes.EUROPEAN
     option_type = OptionTypes.EUROPEAN_CALL
-    num_steps_per_year = 50
-    params = np.array([1.0, strike_price])
+    num_steps_per_year = 2000
 
     v = black_scholes_fd_PSOR(spot_price=spot_price, volatility=volatility,
-                                        time_to_expiry=time_to_expiry,
-                                        strike_price=strike_price, risk_free_rate=risk_free_rate,
-                                        dividend_yield=dividend_yield, digital=0,
-                                        option_type=option_type, smooth=0, theta=0.5,
-                                        )
-    tree = EquityBinomialTree()
-    value = tree.value(
-        spot_price,
-        discount_curve,
-        dividend_curve,
-        volatility,
-        num_steps_per_year,
-        valuation_date,
-        payoff,
-        expiry_date,
-        payoff,
-        exercise,
-        params)  # price, delta, gamma, theta
-    assert v == approx(value[0], abs=1e-1)
+                              time_to_expiry=time_to_expiry,
+                              strike_price=strike_price, risk_free_rate=risk_free_rate,
+                              dividend_yield=dividend_yield, digital=0,
+                              option_type=option_type, smooth=0, theta=0.5,
+                              )
+    value = crr_tree_val_avg(spot_price,
+                             risk_free_rate,  # continuously compounded
+                             dividend_yield,  # continuously compounded
+                             volatility,  # Black scholes volatility
+                             num_steps_per_year,
+                             time_to_expiry,
+                             option_type.value,
+                             strike_price)
+    assert v == approx(value['value'], abs=1e-3)
+
 
 
 def test_european_put():
@@ -151,14 +139,9 @@ def test_european_put():
     valuation_date = Date(1, 1, 2016)
     expiry_date = Date(1, 1, 2021)
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
-    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
-    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
-    num_steps_per_year = 100
+    num_steps_per_year = 2000
     strike_price = 50.0
-    payoff = EquityTreePayoffTypes.VANILLA_OPTION
-    exercise = EquityTreeExerciseTypes.EUROPEAN
     option_type = OptionTypes.EUROPEAN_PUT
-    params = np.array([-1.0, strike_price])
 
     v = black_scholes_fd_PSOR(spot_price=spot_price, volatility=volatility,
                               time_to_expiry=time_to_expiry,
@@ -166,20 +149,15 @@ def test_european_put():
                               dividend_yield=dividend_yield, digital=0,
                               option_type=option_type, smooth=0, theta=0.5,
                               )
-    tree = EquityBinomialTree()
-    value = tree.value(
-        spot_price,
-        discount_curve,
-        dividend_curve,
-        volatility,
-        num_steps_per_year,
-        valuation_date,
-        payoff,
-        expiry_date,
-        payoff,
-        exercise,
-        params)  # price, delta, gamma, theta
-    assert v == approx(value[0], abs=1e-1)
+    value = crr_tree_val_avg(spot_price,
+                             risk_free_rate,  # continuously compounded
+                             dividend_yield,  # continuously compounded
+                             volatility,  # Black scholes volatility
+                             num_steps_per_year,
+                             time_to_expiry,
+                             option_type.value,
+                             strike_price)
+    assert v == approx(value['value'], abs=1e-3)
 
 
 def test_american_call():
@@ -194,35 +172,26 @@ def test_american_call():
     valuation_date = Date(1, 1, 2016)
     expiry_date = Date(1, 1, 2021)
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
-    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
-    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
-    num_steps_per_year = 100
+    num_steps_per_year = 2000
     strike_price = 50.0
-    payoff = EquityTreePayoffTypes.VANILLA_OPTION
-    exercise = EquityTreeExerciseTypes.AMERICAN
     option_type = OptionTypes.AMERICAN_CALL
-    params = np.array([1.0, strike_price])
 
     v = black_scholes_fd_PSOR(spot_price=spot_price, volatility=volatility,
-                                        time_to_expiry=time_to_expiry,
-                                        strike_price=strike_price, risk_free_rate=risk_free_rate,
-                                        dividend_yield=dividend_yield, digital=0,
-                                        option_type=option_type, smooth=0, theta=0.5,
-                                        )
-    tree = EquityBinomialTree()
-    value = tree.value(
-        spot_price,
-        discount_curve,
-        dividend_curve,
-        volatility,
-        num_steps_per_year,
-        valuation_date,
-        payoff,
-        expiry_date,
-        payoff,
-        exercise,
-        params)  # price, delta, gamma, theta
-    assert v == approx(value[0], abs=1e-1)
+                              time_to_expiry=time_to_expiry,
+                              strike_price=strike_price, risk_free_rate=risk_free_rate,
+                              dividend_yield=dividend_yield, digital=0,
+                              option_type=option_type, smooth=0, theta=0.5,
+                              )
+    value = crr_tree_val_avg(spot_price,
+                             risk_free_rate,  # continuously compounded
+                             dividend_yield,  # continuously compounded
+                             volatility,  # Black scholes volatility
+                             num_steps_per_year,
+                             time_to_expiry,
+                             option_type.value,
+                             strike_price)
+    assert v == approx(value['value'], abs=1e-3)
+
 
 
 def test_american_put():
@@ -237,14 +206,9 @@ def test_american_put():
     valuation_date = Date(1, 1, 2016)
     expiry_date = Date(1, 1, 2021)
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
-    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
-    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
-    num_steps_per_year = 100
+    num_steps_per_year = 2000
     strike_price = 50.0
-    payoff = EquityTreePayoffTypes.VANILLA_OPTION
-    exercise = EquityTreeExerciseTypes.AMERICAN
     option_type = OptionTypes.AMERICAN_PUT
-    params = np.array([-1.0, strike_price])
 
     v = black_scholes_fd_PSOR(spot_price=spot_price, volatility=volatility,
                               time_to_expiry=time_to_expiry,
@@ -252,20 +216,15 @@ def test_american_put():
                               dividend_yield=dividend_yield, digital=0,
                               option_type=option_type, smooth=0, theta=0.5,
                               )
-    tree = EquityBinomialTree()
-    value = tree.value(
-        spot_price,
-        discount_curve,
-        dividend_curve,
-        volatility,
-        num_steps_per_year,
-        valuation_date,
-        payoff,
-        expiry_date,
-        payoff,
-        exercise,
-        params)  # price, delta, gamma, theta
-    assert v == approx(value[0], abs=1e-1)
+    value = crr_tree_val_avg(spot_price,
+                             risk_free_rate,  # continuously compounded
+                             dividend_yield,  # continuously compounded
+                             volatility,  # Black scholes volatility
+                             num_steps_per_year,
+                             time_to_expiry,
+                             option_type.value,
+                             strike_price)
+    assert v == approx(value['value'], abs=1e-3)
 
 
 def test_call_option():


### PR DESCRIPTION
Change finite difference tests to compare against CRR tree rather than EquityBinomialTree. I think this is the correct comparison (and the results are certainly much closer).

A couple of other changes to improve the finite difference models

1. Finite difference model now has a fixed number of time steps rather than scaling the number of time steps with the time to expiry. This was recommended in the Andreasen lecture notes and fixes the issue of this model getting noticably less accurate as time to expiry increases. With this change, the finite difference model can match the CRR tree to 1e-5 for a suitably large number of samples.
2. Increase the default maximum sample in the PSOR model. It was set to be 4 times the maximum of stock and strike price, but increasing to 10 times seems to increase accuracy quite a lot. With this change, the PSOR model can match the CRR tree to 1e-3, but doesn't seem to get any closer with more samples, which is odd. 
