### PR TITLE
PSOR model rewrite

### DIFF
--- a/financepy/models/finite_difference_PSOR.py
+++ b/financepy/models/finite_difference_PSOR.py
@@ -73,7 +73,7 @@ def PSOR_roll_backwards(Ae, Ai, delta_bound, option_type, payoff, res_k, num_ste
 
 
 @njit(fastmath=True, cache=True)
-def PSOR(Ai, acc, omega, initial_value, z_ip1):
+def PSOR(Ai, acc, omega, initial_value, z_ip1, max_iter=1000):
     nloops = 0
     res_k = initial_value
     res_kp1 = initial_value.copy()
@@ -88,10 +88,9 @@ def PSOR(Ai, acc, omega, initial_value, z_ip1):
             res_kp1[j] = omega * res_kp1[j] + (1 - omega) * res_k[j]
 
         # Calculate change compared to previous iteration
-        delta_new = np.sum((res_kp1 - res_k) ** 2)
-        if delta_new > delta and nloops > 0:
+        delta = np.sum((res_kp1 - res_k) ** 2)
+        if nloops > max_iter:
             raise RuntimeError("Calculation is not converging")
-        delta = delta_new
 
         # roll back i.e. k+1 -> k
         res_k = res_kp1.copy()

--- a/financepy/models/finite_difference_PSOR.py
+++ b/financepy/models/finite_difference_PSOR.py
@@ -10,8 +10,16 @@ from .finite_difference import option_payoff, calculate_fd_matrix
 
 def black_scholes_fd_PSOR(spot_price, volatility, time_to_expiry,
                           strike_price, risk_free_rate, dividend_yield, option_type,
-                          num_time_steps=None, num_samples=5000, num_std=5, theta=0.5, wind=0, digital=False,
-                          smooth=False):
+                          num_time_steps=None, num_samples=2000, num_std=5, theta=0.5, wind=0, digital=False,
+                          smooth=False, acc=1e-13, d_omega=5e-5, max_iter=0):
+    """
+    Solve Black-Scholes equation using projected successive over-relaxtion.
+
+    Parameters:
+        acc: Keep iterating until this accuracy is achieved
+        d_omega: Larger numbers lead to bigger changes in omega with each iteration
+        max_iter: Maximum number of iterations in PSOR step. Set to 0 to allow any number of iterations.
+    """
     if isinstance(option_type, OptionTypes):
         option_type = option_type.value
 
@@ -40,7 +48,7 @@ def black_scholes_fd_PSOR(spot_price, volatility, time_to_expiry,
     mu_ = mu * s
     var_ = (s * volatility) ** 2
 
-    # Store original res as res0
+    # Result starts as the payoff and we iterate backwards
     res = deepcopy(payoff)[0]
 
     # Explicit
@@ -49,8 +57,16 @@ def black_scholes_fd_PSOR(spot_price, volatility, time_to_expiry,
     Ai = calculate_fd_matrix(s, r_, mu_, var_, -dt, theta, wind)
 
     # Loop backwards through timesteps
+    omega = 1.8  # Start with a higher number for faster convergence and lower as estimation improves
+    previous_nloops = 0
     for _ in range(num_steps - 1, -1, -1):
-        res = PSOR_roll_backwards(res_k=res, acc=1e-5, Ai=Ai, Ae=Ae)
+        res, nloops = PSOR_roll_backwards(res_k=res, acc=acc, Ai=Ai, Ae=Ae, omega=omega, max_iter=max_iter)
+
+        # Increase omega if nloops is larger this iteration. Decrease if nloops is less. Otherwise stay the same.
+        omega += np.sign(nloops - previous_nloops) * d_omega
+        omega = min(max(omega, 1 + d_omega), 2 - d_omega)  # Omega must be between 1 and 2
+
+        previous_nloops = nloops
 
         # Early exit for American options
         if option_type in {OptionTypes.AMERICAN_CALL.value, OptionTypes.AMERICAN_PUT.value}:
@@ -61,18 +77,32 @@ def black_scholes_fd_PSOR(spot_price, volatility, time_to_expiry,
 
 
 @njit(fastmath=True, cache=True)
-def PSOR_roll_backwards(Ae, Ai, acc, res_k):
+def PSOR_roll_backwards(Ae, Ai, res_k, omega, acc=1e-13, max_iter=0):
     # Explicit step
     z_ip1 = band_matrix_multiplication(Ae, 1, 1, res_k)
 
     # PSOR - Iterate until the total change in res is less than acc
-    omega = 1.9  # TODO Dynamically update omega
-    res_k = PSOR(Ai, omega, res_k, z_ip1, acc=acc)
-    return res_k
+    res_k, nloops = PSOR(Ai, omega, res_k, z_ip1, acc=acc, max_iter=max_iter)
+    return res_k, nloops
 
 
 @njit(fastmath=True, cache=True)
-def PSOR(Ai, omega, initial_value, z_ip1, max_iter=1000, acc=1e-5):
+def PSOR(Ai, omega, initial_value, z_ip1, max_iter=0, acc=1e-13):
+    """
+    Projected Successive Over Relaxation -
+
+    Parameters:
+        Ai (np.array): Implicit finite difference matrix
+        omega (float): Number between 1 and 2 weighted average of previous and currect iteration
+        initial_value (np.array): Vector produced by previous iteration
+        z_ip1 (matrix): Matrix for updating to next timestep
+        max_iter (int): Maximum number of iterations before raising an error (max_iter=0 means no maximum)
+        acc (float): Accuracy. The maximum acceptable square difference between two iterations
+
+    Returns:
+        res_k (np.array): Vector for next time step
+        nloops (int): The number of iterations required to achieve required accuracy
+    """
     nloops = 0
     res_k = initial_value
     res_kp1 = initial_value.copy()
@@ -89,12 +119,12 @@ def PSOR(Ai, omega, initial_value, z_ip1, max_iter=1000, acc=1e-5):
 
         # Calculate change compared to previous iteration
         delta = np.sum((res_kp1 - res_k) ** 2)
-        if nloops > max_iter:
+        if max_iter != 0 and nloops > max_iter:
             raise RuntimeError("Calculation is not converging")
 
         # roll back i.e. k+1 -> k
         res_k = res_kp1.copy()
 
-        nloops +=1
+        nloops += 1
 
-    return res_k
+    return res_k, nloops

--- a/financepy/models/finite_difference_PSOR.py
+++ b/financepy/models/finite_difference_PSOR.py
@@ -1,126 +1,101 @@
 from copy import deepcopy
 
 import numpy as np
+from numba import njit
 
-from financepy.utils.math import solve_tridiagonal_matrix, band_matrix_multiplication
-from financepy.models.finite_difference import option_payoff
+from ..utils.math import band_matrix_multiplication
 from financepy.utils.global_types import OptionTypes
-
-
-def calculate_fd_PSOR_matrix(x, risk_free_rate, mu, volatility, dt, theta):
-    j = np.arange(len(x))
-    alpha = 0.5 * dt * theta * (volatility**2 * j**2 - mu * j)
-    beta = 1 - dt * theta * (volatility**2 * j**2 + risk_free_rate)
-    kappa = 0.5 * dt * theta * (volatility**2 * j**2 + mu * j)
-    return np.array([alpha, beta, kappa])
+from .finite_difference import option_payoff, calculate_fd_matrix
 
 
 def black_scholes_fd_PSOR(spot_price, volatility, time_to_expiry,
                           strike_price, risk_free_rate, dividend_yield, option_type,
-                          num_steps=None, num_samples=None, s_max=None, theta=0.5, digital=False,
-                          smooth=False, delta_bound=1e-5, omega=0.5):
-    """
-    Solve the Black Scholes equation using the Projected Successive Over Relaxation (PSOR) method.
-    This is based on the method outlined here:
-    https://www.diva-portal.org/smash/get/diva2:620212/fulltext01.pdf
-
-    This method uses a uniform grid.
-
-    The parameters specific to this model a described below
-
-    Parameters:
-        num_steps: Number of time steps used
-        num_samples: Number of stock prices the model evalutates
-        s_max: Maximum stock price evaluated
-
-        theta: Parameter used for theta solver. Set to 0.5 for Crank Nicolson method
-
-        digital: True when payoff digital
-        smooth: True when payoff is smooth
-
-        delta_bound: PSOR with iterate until the square difference over the curve is less than this value
-        omega: Weighting parameter for PSOR, balancing previous and current iteration
-    """
+                          num_time_steps=None, num_samples=5000, num_std=5, theta=0.5, wind=0, digital=False,
+                          smooth=False):
     if isinstance(option_type, OptionTypes):
         option_type = option_type.value
 
-    # Set default values
-    s_max = s_max or max(strike_price, spot_price) * 10
-    num_samples = num_samples or s_max * 10
-    num_steps = num_steps or int(num_samples // 2)
+    # Define grid
+    std = volatility * (time_to_expiry ** 0.5)
+    xu = num_std * std
+    xl = -xu
+    d_x = (xu - xl) / max(1, num_samples)
+    num_samples = 1 if num_samples <= 0 or xl == xu else num_samples + 1
 
-    # Define grid over stock value and timesteps
-    dx = s_max / num_samples
-    s = np.arange(s_max, step=dx)
-    dt = time_to_expiry / max(1, num_steps)
-    timesteps = np.arange(0, num_steps + 1) * dt
-
-    # Define payoff for option as curve in our grid
-    payoff = option_payoff(s, strike_price, smooth, digital, option_type)
-
-    # Set drift parameter
+    # Calculate the drift
     mu = risk_free_rate - dividend_yield
 
-    # Boundary condition is the payoff of the option at expiry.
-    # Start here and iterate backwards
-    res_k = deepcopy(payoff)[0]
+    # Create sample set s
+    s = spot_price * np.exp(xl + d_x * np.arange(0, num_samples))
 
-    # Explicit matrix
-    Ae = calculate_fd_PSOR_matrix(s, risk_free_rate, mu, volatility, dt, 1 - theta).T
-    alpha, beta, kappa = Ae.T
+    # Generate the option payoff to be fitted
+    payoff = option_payoff(s, strike_price, smooth, digital, option_type)
 
-    # Implicit matrix
-    Ai = calculate_fd_PSOR_matrix(s, risk_free_rate, mu, volatility, -dt, theta).T
-    a, b, c = Ai.T
+    # time steps
+    num_steps = num_time_steps or num_samples // 4
+    dt = time_to_expiry / max(1, num_steps)
 
-    # set boundary conditions at s=0 and s=infinity for each timestep
-    if option_type in {OptionTypes.EUROPEAN_CALL.value, OptionTypes.AMERICAN_CALL.value}:
-        f0 = np.zeros(num_steps + 1)
-        fM = s_max - strike_price * np.exp(-risk_free_rate * (time_to_expiry - timesteps))
-    elif option_type in {OptionTypes.EUROPEAN_PUT.value, OptionTypes.AMERICAN_PUT.value}:
-        f0 = strike_price * np.exp(-risk_free_rate * (time_to_expiry - timesteps))
-        fM = np.zeros(num_steps + 1)
-    else:
-        raise ValueError("Option type not valid for this model")
+    # Make time series for interest rate, drift, and variance
+    r_ = np.zeros(num_samples) + risk_free_rate
+    mu_ = mu * s
+    var_ = (s * volatility) ** 2
 
+    # Store original res as res0
+    res = deepcopy(payoff)[0]
+
+    # Explicit
+    Ae = calculate_fd_matrix(s, r_, mu_, var_, dt, 1-theta, wind)
+    # Implicit
+    Ai = calculate_fd_matrix(s, r_, mu_, var_, -dt, theta, wind)
+
+    res = PSOR_roll_backwards(res_k=res, payoff=payoff, option_type=option_type, delta_bound=1e-5, Ai=Ai, Ae=Ae,
+                              num_steps=num_steps)
+
+    return res[num_samples // 2]
+
+
+@njit(fastmath=True, cache=True)
+def PSOR_roll_backwards(Ae, Ai, delta_bound, option_type, payoff, res_k, num_steps):
+    # Loop backwards through timesteps
     for i in range(num_steps - 1, -1, -1):
-        # Iterate for until solution is stable
-        delta = 1
-
         # Explicit step
         z_ip1 = band_matrix_multiplication(Ae, 1, 1, res_k)
 
-        # Apply boundary conditions
-        z_ip1[0] += alpha[0] * f0[i + 1]
-        z_ip1[-1] += kappa[-1] * fM[i + 1]
-
-        # Don't want to change z in place, as we need it later, so deepcopy it
-        res_k = deepcopy(z_ip1)
-
-        # Apply boundary conditions
-        res_k[0] -= a[0] * f0[i]
-        res_k[-1] -= c[-1] * fM[i]
-
-        # Implicit step
-        res_k = solve_tridiagonal_matrix(Ai, res_k)
-
         # PSOR - Iterate until the total change in res is less than delta_bound
-        while delta >= delta_bound:
-            res_kp1 = (z_ip1 - a * np.roll(res_k, 1) - c * np.roll(res_k, -1)) / b
-            res_kp1[0] = res_k[0]
-            res_kp1[-1] = res_k[-1]
-            res_kp1 = omega * res_k + (1 - omega) * res_kp1
-
-            # Calculate change compared to previous iteration
-            delta = np.sum((res_kp1 - res_k) ** 2)
-
-            # roll back i.e. k+1 -> k
-            res_k = deepcopy(res_kp1)
+        omega = 1.9  # TODO Dynamically update omega
+        res_k = PSOR(Ai, delta_bound, omega, res_k, z_ip1)
 
         # Early exit for American options
         if option_type in {OptionTypes.AMERICAN_CALL.value, OptionTypes.AMERICAN_PUT.value}:
             idx = res_k < payoff[0]
             res_k[idx] = payoff[0][idx]
+    return res_k
 
-    # Interpolate in case spot price doesn't fall exactly on grid value
-    return np.interp(spot_price, s, res_k)
+
+@njit(fastmath=True, cache=True)
+def PSOR(Ai, acc, omega, initial_value, z_ip1):
+    nloops = 0
+    res_k = initial_value
+    res_kp1 = initial_value.copy()
+    delta = 1
+    a, b, c = Ai.T
+
+    # Iterate for until solution is stable
+    while delta >= acc:
+        for j in range(1, len(res_k)-1):
+            res_kp1[j] = (z_ip1[j] - a[j] * res_kp1[j-1] - c[j] * res_k[j+1]) / b[j]
+
+            res_kp1[j] = omega * res_kp1[j] + (1 - omega) * res_k[j]
+
+        # Calculate change compared to previous iteration
+        delta_new = np.sum((res_kp1 - res_k) ** 2)
+        if delta_new > delta and nloops > 0:
+            raise RuntimeError("Calculation is not converging")
+        delta = delta_new
+
+        # roll back i.e. k+1 -> k
+        res_k = res_kp1.copy()
+
+        nloops +=1
+
+    return res_k

--- a/notebooks/models/FINITE_DIFFERENCE_PSOR.ipynb
+++ b/notebooks/models/FINITE_DIFFERENCE_PSOR.ipynb
@@ -23,6 +23,7 @@
     "from financepy.models.finite_difference_PSOR import black_scholes_fd_PSOR\n",
     "from financepy.models.finite_difference import option_payoff\n",
     "from financepy.products.equity import OptionTypes, Date\n",
+    "from financepy.utils.global_vars import gDaysInYear\n",
     "\n",
     "from copy import deepcopy\n",
     "\n",
@@ -37,22 +38,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "expiry_date = Date(1, 7, 2015)\n",
+    "strike_price = 100.0\n",
     "option_type = OptionTypes.EUROPEAN_CALL\n",
+    "\n",
     "valuation_date = Date(1, 1, 2015)\n",
-    "expiry_date = valuation_date.add_years(0.5)\n",
-    "time_to_expiry = (expiry_date - valuation_date) / 365.0\n",
+    "stock_price = 100\n",
+    "volatility = 0.30\n",
     "risk_free_rate = 0.05\n",
-    "spot_price = 50.0\n",
-    "smooth = digital = False\n",
-    "volatility = 0.20\n",
-    "dividend_yield = 0.0\n",
-    "strike_price = 50.0\n",
+    "dividend_yield = 0.01\n",
+    "num_std = 5\n",
+    "num_samples = 2000\n",
     "\n",
-    "s_max = strike_price * 4\n",
-    "dx = 0.1\n",
-    "num_samples = s_max / dx\n",
-    "\n",
-    "theta = 0.5"
+    "# Time to contract expiry in years\n",
+    "time_to_expiry = (expiry_date - valuation_date) / gDaysInYear\n"
    ]
   },
   {
@@ -64,27 +63,17 @@
    },
    "outputs": [],
    "source": [
-    "res = black_scholes_fd_PSOR(spot_price, volatility, time_to_expiry,\n",
-    "                            strike_price, risk_free_rate, dividend_yield, option_type,\n",
-    "                            num_steps=None, num_samples=None, s_max=None, theta=0.5, digital=False,\n",
-    "                            smooth=False, delta_bound=1e-5, omega=0.5)"
+    "res = black_scholes_fd_PSOR(spot_price=stock_price, volatility=volatility,\n",
+    "                                    time_to_expiry=time_to_expiry,\n",
+    "                                    strike_price=100.0, risk_free_rate=risk_free_rate,\n",
+    "                                    dividend_yield=dividend_yield, digital=0,\n",
+    "                                    option_type=option_type, smooth=0, theta=0.5, wind=0,\n",
+    "                                    num_std=5, num_time_steps=None, num_samples=num_samples)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9e70fee6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dx = s_max / num_samples\n",
-    "s = np.arange(s_max, step=dx)\n",
-    "payoff = option_payoff(s, strike_price, smooth, digital, option_type)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "id": "a82d9c11",
    "metadata": {
     "scrolled": true
@@ -94,12 +83,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Value of option is $3.4275929231736493\n"
+      "Value of option is $9.302028751692234\n"
      ]
     }
    ],
    "source": [
-    "sample = np.argmin(np.abs(s-spot_price))\n",
     "print(f\"Value of option is ${res}\")"
    ]
   },

--- a/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
+++ b/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:57.562888Z",
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.733804Z",
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.741755Z",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.748736Z",
@@ -113,25 +113,14 @@
      "shell.execute_reply": "2021-01-17T21:44:58.751728Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "01-JUL-2015"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "expiry_date"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.753750Z",
@@ -147,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.757904Z",
@@ -171,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.761865Z",
@@ -187,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.766045Z",
@@ -210,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.770033Z",
@@ -226,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.780976Z",
@@ -242,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.786959Z",
@@ -258,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.793940Z",
@@ -274,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.799956Z",
@@ -283,26 +272,14 @@
      "shell.execute_reply": "2021-01-17T21:44:58.801965Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OBJECT TYPE: EquityAmericanOption\n",
-      "EXPIRY DATE: 01-JUL-2015\n",
-      "STRIKE PRICE: 50.0\n",
-      "OPTION TYPE: OptionTypes.AMERICAN_CALL\n",
-      "NUMBER: 1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(americanCallOption)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.805909Z",
@@ -311,19 +288,7 @@
      "shell.execute_reply": "2021-01-17T21:44:58.807968Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OBJECT TYPE: EquityAmericanOption\n",
-      "EXPIRY DATE: 01-JUL-2015\n",
-      "STRIKE PRICE: 50.0\n",
-      "OPTION TYPE: OptionTypes.AMERICAN_PUT\n",
-      "NUMBER: 1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(americanPutOption)"
    ]
@@ -337,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.810931Z",
@@ -356,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.817911Z",
@@ -372,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.822898Z",
@@ -395,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.827915Z",
@@ -411,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.831874Z",
@@ -420,25 +385,14 @@
      "shell.execute_reply": "2021-01-17T21:44:58.833897Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4276581469416914"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.835863Z",
@@ -447,18 +401,7 @@
      "shell.execute_reply": "2021-01-17T21:44:58.837886Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4276581469416914"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -472,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,122 +430,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4276581469416914"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4276540933598305"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4276540933598305"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.2031750852278296"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.2031710315837243"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanAmericanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.319903905249911"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -616,15 +493,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "params = {\n",
     "    'theta': 0.5,\n",
     "    'num_samples': 2000,\n",
-    "    'delta_bound': 1e-5,\n",
-    "    'omega': 0.5\n",
     "}\n",
     "model = BlackScholes(volatility,\n",
     "                     implementationType=BlackScholesTypes.PSOR,\n",
@@ -633,122 +508,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4276581469416914"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4275929231736475"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4275929231736475"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.2031750852278296"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.2031098613969817"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanAmericanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.3198330427695675"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -763,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -772,47 +581,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.4276581469416914"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.427145909428062"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.839882Z",
@@ -821,58 +608,25 @@
      "shell.execute_reply": "2021-01-17T21:44:59.029389Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.427145909428062"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.2031750852278296"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.2026628477140777"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "europeanAmericanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -886,20 +640,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.3227588252294726"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -927,80 +670,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.6240485077846358"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanCallOption.delta(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "534.1064689190489"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanCallOption.gamma(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-4.0724784861637575"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanCallOption.theta(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "13.096682231981127"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "americanCallOption.rho(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]

--- a/tests/test_finite_difference_PSOR.py
+++ b/tests/test_finite_difference_PSOR.py
@@ -92,7 +92,6 @@ def test_black_scholes_fd_PSOR():
     option_type = OptionTypes.EUROPEAN_CALL
 
 
-
 def test_european_call():
     """
     Check finite difference method gives similar result to binomial tree
@@ -124,7 +123,6 @@ def test_european_call():
                              option_type.value,
                              strike_price)
     assert v == approx(value['value'], abs=1e-3)
-
 
 
 def test_european_put():
@@ -181,6 +179,7 @@ def test_american_call():
                               strike_price=strike_price, risk_free_rate=risk_free_rate,
                               dividend_yield=dividend_yield, digital=0,
                               option_type=option_type, smooth=0, theta=0.5,
+                              num_samples=5000
                               )
     value = crr_tree_val_avg(spot_price,
                              risk_free_rate,  # continuously compounded
@@ -191,7 +190,6 @@ def test_american_call():
                              option_type.value,
                              strike_price)
     assert v == approx(value['value'], abs=1e-3)
-
 
 
 def test_american_put():
@@ -214,7 +212,8 @@ def test_american_put():
                               time_to_expiry=time_to_expiry,
                               strike_price=strike_price, risk_free_rate=risk_free_rate,
                               dividend_yield=dividend_yield, digital=0,
-                              option_type=option_type, smooth=0
+                              option_type=option_type, smooth=0,
+                              num_samples=5000
                               )
     value = crr_tree_val_avg(spot_price,
                              risk_free_rate,  # continuously compounded

--- a/tests/test_finite_difference_PSOR.py
+++ b/tests/test_finite_difference_PSOR.py
@@ -214,7 +214,7 @@ def test_american_put():
                               time_to_expiry=time_to_expiry,
                               strike_price=strike_price, risk_free_rate=risk_free_rate,
                               dividend_yield=dividend_yield, digital=0,
-                              option_type=option_type, smooth=0, theta=0.5,
+                              option_type=option_type, smooth=0
                               )
     value = crr_tree_val_avg(spot_price,
                              risk_free_rate,  # continuously compounded


### PR DESCRIPTION
Totally rewrote the PSOR model. It now uses the same grid as the original finite difference model, and updates the weighting parameter (omega) to allow faster convergence. Most importantly, it now converges to the finite difference and CRR tree models in the limits. 