### PR TITLE
LSMC model update

### DIFF
--- a/financepy/models/black_scholes.py
+++ b/financepy/models/black_scholes.py
@@ -177,8 +177,9 @@ class BlackScholes(Model):
                                 time_to_expiry,
                                 option_type.value,
                                 strike_price,
-                                self._seed,
-                                self._use_sobol)
+                                seed=self._seed,
+                                use_sobol=self._use_sobol,
+                                **self._params)
 
                 return v
             elif self._implementationType == BlackScholesTypes.Bjerksund_Stensland:

--- a/financepy/models/black_scholes.py
+++ b/financepy/models/black_scholes.py
@@ -125,6 +125,22 @@ class BlackScholes(Model):
                                           **self._params
                                           )
                 return v
+            elif self._implementationType == BlackScholesTypes.LSMC:
+
+                v = equity_lsmc(spot_price=spotPrice,
+                                risk_free_rate=risk_free_rate,
+                                dividend_yield=dividendRate,
+                                sigma=self._volatility,
+                                num_paths=self._num_paths,
+                                num_steps_per_year=self._num_steps_per_year,
+                                time_to_expiry=time_to_expiry,
+                                option_type_value=option_type.value,
+                                strike_price=strike_price,
+                                seed=self._seed,
+                                use_sobol=self._use_sobol,
+                                **self._params)
+
+                return v
 
             else:
 
@@ -168,15 +184,15 @@ class BlackScholes(Model):
 
             elif self._implementationType == BlackScholesTypes.LSMC:
 
-                v = equity_lsmc(spotPrice,
-                                risk_free_rate,
-                                dividendRate,
-                                self._volatility,
-                                self._num_steps_per_year,
-                                self._num_paths,
-                                time_to_expiry,
-                                option_type.value,
-                                strike_price,
+                v = equity_lsmc(spot_price=spotPrice,
+                                risk_free_rate=risk_free_rate,
+                                dividend_yield=dividendRate,
+                                sigma=self._volatility,
+                                num_paths=self._num_paths,
+                                num_steps_per_year=self._num_steps_per_year,
+                                time_to_expiry=time_to_expiry,
+                                option_type_value=option_type.value,
+                                strike_price=strike_price,
                                 seed=self._seed,
                                 use_sobol=self._use_sobol,
                                 **self._params)

--- a/financepy/models/equity_lsmc.py
+++ b/financepy/models/equity_lsmc.py
@@ -10,42 +10,48 @@ import sys
 import numpy as np
 from numba import jit, njit, float64, int64
 
+from enum import Enum, auto
+
 from ..utils.global_types import OptionTypes
 from ..utils.error import FinError
 from ..utils.polyfit import fit_poly, eval_polynomial
 from ..models.sobol import get_gaussian_sobol
+from ..models.finite_difference import option_payoff
 
 import matplotlib.pyplot as plt
 
 # This is a first implementation of American Monte Carlo using the method of 
 # Longstaff and Schwartz. Work is needed to add laguerre Polynomials and 
 # other interpolation methods.
+class FIT_TYPES(Enum):
+    HERMITE_E = auto()
+    LAGUERRE = auto()
+    HERMITE = auto()
+    LEGENDRE = auto()
+    CHEBYCHEV = auto()
+    POLYNOMIAL = auto()
+
 
 #@njit(float64(float64, float64, float64, float64, int64, int64, float64, int64,
 #                 float64, int64, int64, int64), fastmath=True, cache=False)
-def equity_lsmc(s0, r, q, v,
-                num_steps_per_year,
-                num_paths,
-                texp,
-                option_type_value,
-                k,
-                poly_degree,
-                use_sobol,
-                seed):
+def equity_lsmc(spot_price, risk_free_rate, dividend_yield, sigma, num_steps_per_year, num_paths, time_to_expiry,
+                option_type_value, strike_price, poly_degree, fit_type, use_sobol, seed):
     
     if num_paths == 0:
         raise FinError("Num Paths is zero")
+    if fit_type is None:
+        fit_type = FIT_TYPES.LAGUERRE
     
     np.random.seed(seed)
 
-    num_steps = int(num_steps_per_year * texp)
+    num_steps = int(num_steps_per_year * time_to_expiry)
     num_times = num_steps + 1
 
-    dt = texp / num_times
-    times = np.linspace(0, texp, num_times)
+    dt = time_to_expiry / num_times
+    times = np.linspace(0, time_to_expiry, num_times)
     rootdt = np.sqrt(dt)
     
-    mu = r - q - 0.5 * v**2
+    mu = risk_free_rate - dividend_yield - 0.5 * sigma ** 2
 
     if num_paths % 2 == 1:
         num_paths = num_paths + 1
@@ -53,27 +59,23 @@ def equity_lsmc(s0, r, q, v,
     half_num_paths = int(num_paths/2.0)
 
     st = np.zeros((num_times, num_paths), 'd')  # stock price matrix
-    st[0] = s0
+    st[0] = spot_price
 
+    gp = np.random.standard_normal((half_num_paths, num_times))
+    g = np.concatenate((gp, -gp))
     for it in range(1, num_times):
-        gp = np.random.standard_normal(half_num_paths)
-        g = np.concatenate((gp, -gp))
-        st[it] = st[it-1] * np.exp(mu * dt + v * g * rootdt)
+        st[it] = st[it-1] * np.exp(mu * dt + sigma * g[:, it] * rootdt)
 
     
     # ensure forward price is recovered exactly
     for it in range(0, num_times):
-        t = times[it]
         fmean = np.mean(st[it])
-        fexact = s0 * np.exp((r-q)*t)
+        fexact = spot_price * np.exp((risk_free_rate - dividend_yield) * times[it])
         st[it] = st[it] * fexact / fmean
-        
-    if option_type_value == OptionTypes.AMERICAN_CALL.value:
-        exercise_matrix = np.maximum(st - k, 0.0)
-    elif option_type_value == OptionTypes.AMERICAN_PUT.value:
-        exercise_matrix = np.maximum(k - st, 0.0)
-    else:
-        raise FinError("Unknown option type.")
+
+    exercise_matrix = np.zeros_like(st)
+    for i in range(exercise_matrix.shape[0]):
+        exercise_matrix[i] = option_payoff(st[i], strike_price, smooth=False, dig=False, option_type=option_type_value)
 
     # Set final values for value_matrix and stopping matrix
     value_matrix = np.zeros((exercise_matrix.shape))
@@ -81,13 +83,29 @@ def equity_lsmc(s0, r, q, v,
     stopping = np.zeros_like(value_matrix)
     stopping[-1] = np.where(exercise_matrix[-1] > 0, 1, 0)
 
-    df = np.exp(-r * dt)
+    df = np.exp(-risk_free_rate * dt)
     for it in range(num_times-2, 0, -1):
-        regression2 = np.polynomial.laguerre.lagfit(st[it], value_matrix[it + 1] * df, poly_degree)
-        cont_value = np.polynomial.laguerre.lagval(st[it], regression2)
-        #vander = np.vander(st[it], poly_degree+1)
-        #regression2 = np.linalg.lstsq(vander, value_matrix[it+1] * df)[0]
-        #cont_value = eval_polynomial(regression2, st[it])
+        if fit_type == FIT_TYPES.HERMITE_E:
+            regression2 = np.polynomial.hermite_e.hermefit(st[it], value_matrix[it + 1] * df, poly_degree)
+            cont_value = np.polynomial.hermite_e.hermeval(st[it], regression2)
+        elif fit_type == FIT_TYPES.LAGUERRE:
+            regression2 = np.polynomial.laguerre.lagfit(st[it], value_matrix[it + 1] * df, poly_degree)
+            cont_value = np.polynomial.laguerre.lagval(st[it], regression2)
+        elif fit_type == FIT_TYPES.HERMITE:
+            regression2 = np.polynomial.hermite.hermfit(st[it], value_matrix[it + 1] * df, poly_degree)
+            cont_value = np.polynomial.hermite.hermval(st[it], regression2)
+        elif fit_type == FIT_TYPES.LEGENDRE:
+            regression2 = np.polynomial.legendre.legfit(st[it], value_matrix[it + 1] * df, poly_degree)
+            cont_value = np.polynomial.legendre.legval(st[it], regression2)
+        elif fit_type == FIT_TYPES.CHEBYCHEV:
+            regression2 = np.polynomial.chebyshev.chebfit(st[it], value_matrix[it + 1] * df, poly_degree)
+            cont_value = np.polynomial.chebyshev.chebval(st[it], regression2)
+        elif fit_type == FIT_TYPES.POLYNOMIAL:
+            vander = np.vander(st[it], poly_degree+1)
+            regression2 = np.linalg.lstsq(vander, value_matrix[it+1] * df)[0]
+            cont_value = eval_polynomial(regression2, st[it])
+        else:
+            raise ValueError(f"Unknown FitType: {fit_type}")
         cont_value[cont_value < 0] = 0
 
         # Should we exercise at this timestep?
@@ -99,12 +117,16 @@ def equity_lsmc(s0, r, q, v,
 
     # for each path find the earliest stopping time
     values = np.zeros(value_matrix.shape[1])
+
     for i in range(value_matrix.shape[1]):
-        # first value in row of stopping matrix that is greater than zero
-        s = np.argmax(stopping.T[i])
+        if option_type_value in {OptionTypes.AMERICAN_PUT.value, OptionTypes.AMERICAN_CALL.value}:
+            # first value in row of stopping matrix that is greater than zero
+            s = np.argmax(stopping.T[i])
+        else:
+            s = -1
 
         # This is the value of the path discounted to present value
-        values[i] = value_matrix[s, i] * np.exp(-r * times[s])
+        values[i] = value_matrix[s, i] * np.exp(-risk_free_rate * times[s])
     value = np.mean(values)
 
     return value

--- a/financepy/models/equity_lsmc.py
+++ b/financepy/models/equity_lsmc.py
@@ -21,14 +21,15 @@ import matplotlib.pyplot as plt
 # Longstaff and Schwartz. Work is needed to add laguerre Polynomials and 
 # other interpolation methods.
 
-@njit(float64(float64, float64, float64, float64, int64, int64, float64, int64,
-                 float64, int64, int64), fastmath=True, cache=False)
+#@njit(float64(float64, float64, float64, float64, int64, int64, float64, int64,
+#                 float64, int64, int64, int64), fastmath=True, cache=False)
 def equity_lsmc(s0, r, q, v,
                 num_steps_per_year,
                 num_paths,
                 texp,
                 option_type_value,
                 k,
+                poly_degree,
                 use_sobol,
                 seed):
     
@@ -40,13 +41,11 @@ def equity_lsmc(s0, r, q, v,
     num_steps = int(num_steps_per_year * texp)
     num_times = num_steps + 1
 
+    dt = texp / num_times
     times = np.linspace(0, texp, num_times)
-    dt = texp / num_steps
     rootdt = np.sqrt(dt)
     
-    vsqrtdt = v * rootdt
-    mu = r - q - v*v/2.0
-    innov = v * rootdt * np.random.standard_normal((num_times, num_paths))
+    mu = r - q - 0.5 * v**2
 
     if num_paths % 2 == 1:
         num_paths = num_paths + 1
@@ -54,12 +53,12 @@ def equity_lsmc(s0, r, q, v,
     half_num_paths = int(num_paths/2.0)
 
     st = np.zeros((num_times, num_paths), 'd')  # stock price matrix
-    st[0, :] = s0
+    st[0] = s0
 
     for it in range(1, num_times):
         gp = np.random.standard_normal(half_num_paths)
         g = np.concatenate((gp, -gp))
-        st[it, :] = st[it-1, :] * np.exp(mu * dt + v * g * rootdt)
+        st[it] = st[it-1] * np.exp(mu * dt + v * g * rootdt)
 
     
     # ensure forward price is recovered exactly
@@ -76,35 +75,38 @@ def equity_lsmc(s0, r, q, v,
     else:
         raise FinError("Unknown option type.")
 
+    # Set final values for value_matrix and stopping matrix
     value_matrix = np.zeros((exercise_matrix.shape))
     value_matrix[-1] = exercise_matrix[-1]
+    stopping = np.zeros_like(value_matrix)
+    stopping[-1] = np.where(exercise_matrix[-1] > 0, 1, 0)
 
-    # number of basis functions
-    poly_degree = 5
-
-    for it in range(num_steps-1, 0, -1):
-
-        df = np.exp(-r * dt)
-
-        regression2 = fit_poly(st[it], 
-                               value_matrix[it+1] * df, 
-                               poly_degree)
-
-        cont_value = eval_polynomial(regression2, st[it])
-
-        if 1 == 0:
-            plt.figure()
-            plt.scatter(st[it], value_matrix[it+1])        
-            plt.title("it = " + str(it))
-            plt.scatter(st[it], cont_value)
-
-        value_matrix[it] = np.where(exercise_matrix[it] > cont_value, 
-                                    exercise_matrix[it], 
-                                    value_matrix[it+1] * df)
-
-    dt = times[1] - times[0]
     df = np.exp(-r * dt)
-    value = df * np.mean(value_matrix[1])
+    for it in range(num_times-2, 0, -1):
+        regression2 = np.polynomial.laguerre.lagfit(st[it], value_matrix[it + 1] * df, poly_degree)
+        cont_value = np.polynomial.laguerre.lagval(st[it], regression2)
+        #vander = np.vander(st[it], poly_degree+1)
+        #regression2 = np.linalg.lstsq(vander, value_matrix[it+1] * df)[0]
+        #cont_value = eval_polynomial(regression2, st[it])
+        cont_value[cont_value < 0] = 0
+
+        # Should we exercise at this timestep?
+        stopping[it] = np.where(exercise_matrix[it] > cont_value, 1, 0)
+
+        value_matrix[it] = np.where(exercise_matrix[it] > cont_value,
+                                    exercise_matrix[it], 
+                                    cont_value)
+
+    # for each path find the earliest stopping time
+    values = np.zeros(value_matrix.shape[1])
+    for i in range(value_matrix.shape[1]):
+        # first value in row of stopping matrix that is greater than zero
+        s = np.argmax(stopping.T[i])
+
+        # This is the value of the path discounted to present value
+        values[i] = value_matrix[s, i] * np.exp(-r * times[s])
+    value = np.mean(values)
+
     return value
 
 ###############################################################################

--- a/financepy/models/equity_lsmc.py
+++ b/financepy/models/equity_lsmc.py
@@ -33,14 +33,14 @@ class FIT_TYPES(Enum):
 
 
 #@njit(float64(float64, float64, float64, float64, int64, int64, float64, int64,
-#                 float64, int64, int64, int64), fastmath=True, cache=False)
+#                 float64, int64, int64, int64, int64), fastmath=True, cache=False)
 def equity_lsmc(spot_price, risk_free_rate, dividend_yield, sigma, num_steps_per_year, num_paths, time_to_expiry,
-                option_type_value, strike_price, poly_degree, fit_type, use_sobol, seed):
+                option_type_value, strike_price, poly_degree, fit_type_value, use_sobol, seed):
     
     if num_paths == 0:
         raise FinError("Num Paths is zero")
-    if fit_type is None:
-        fit_type = FIT_TYPES.LAGUERRE
+    if not fit_type_value:
+        fit_type_value = FIT_TYPES.LAGUERRE.value
     
     np.random.seed(seed)
 
@@ -85,27 +85,27 @@ def equity_lsmc(spot_price, risk_free_rate, dividend_yield, sigma, num_steps_per
 
     df = np.exp(-risk_free_rate * dt)
     for it in range(num_times-2, 0, -1):
-        if fit_type == FIT_TYPES.HERMITE_E:
+        if fit_type_value == FIT_TYPES.HERMITE_E.value:
             regression2 = np.polynomial.hermite_e.hermefit(st[it], value_matrix[it + 1] * df, poly_degree)
             cont_value = np.polynomial.hermite_e.hermeval(st[it], regression2)
-        elif fit_type == FIT_TYPES.LAGUERRE:
+        elif fit_type_value == FIT_TYPES.LAGUERRE.value:
             regression2 = np.polynomial.laguerre.lagfit(st[it], value_matrix[it + 1] * df, poly_degree)
             cont_value = np.polynomial.laguerre.lagval(st[it], regression2)
-        elif fit_type == FIT_TYPES.HERMITE:
+        elif fit_type_value == FIT_TYPES.HERMITE.value:
             regression2 = np.polynomial.hermite.hermfit(st[it], value_matrix[it + 1] * df, poly_degree)
             cont_value = np.polynomial.hermite.hermval(st[it], regression2)
-        elif fit_type == FIT_TYPES.LEGENDRE:
+        elif fit_type_value == FIT_TYPES.LEGENDRE.value:
             regression2 = np.polynomial.legendre.legfit(st[it], value_matrix[it + 1] * df, poly_degree)
             cont_value = np.polynomial.legendre.legval(st[it], regression2)
-        elif fit_type == FIT_TYPES.CHEBYCHEV:
+        elif fit_type_value == FIT_TYPES.CHEBYCHEV.value:
             regression2 = np.polynomial.chebyshev.chebfit(st[it], value_matrix[it + 1] * df, poly_degree)
             cont_value = np.polynomial.chebyshev.chebval(st[it], regression2)
-        elif fit_type == FIT_TYPES.POLYNOMIAL:
+        elif fit_type_value == FIT_TYPES.POLYNOMIAL.value:
             vander = np.vander(st[it], poly_degree+1)
             regression2 = np.linalg.lstsq(vander, value_matrix[it+1] * df)[0]
             cont_value = eval_polynomial(regression2, st[it])
         else:
-            raise ValueError(f"Unknown FitType: {fit_type}")
+            raise ValueError(f"Unknown FitType: {fit_type_value}")
         cont_value[cont_value < 0] = 0
 
         # Should we exercise at this timestep?

--- a/financepy/models/equity_lsmc.py
+++ b/financepy/models/equity_lsmc.py
@@ -101,8 +101,7 @@ def equity_lsmc(spot_price, risk_free_rate, dividend_yield, sigma, num_steps_per
             regression2 = np.polynomial.chebyshev.chebfit(st[it], value_matrix[it + 1] * df, poly_degree)
             cont_value = np.polynomial.chebyshev.chebval(st[it], regression2)
         elif fit_type_value == FIT_TYPES.POLYNOMIAL.value:
-            vander = np.vander(st[it], poly_degree+1)
-            regression2 = np.linalg.lstsq(vander, value_matrix[it+1] * df)[0]
+            regression2 = fit_poly(st[it], value_matrix[it + 1] * df, poly_degree)
             cont_value = eval_polynomial(regression2, st[it])
         else:
             raise ValueError(f"Unknown FitType: {fit_type_value}")

--- a/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
+++ b/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
@@ -769,7 +769,7 @@
     "                     num_steps_per_year=52,\n",
     "                     num_paths=50_000,\n",
     "                     implementationType=BlackScholesTypes.LSMC,\n",
-    "                     params={\"fit_type\": FIT_TYPES.LAGUERRE,\n",
+    "                     params={\"fit_type_value\": FIT_TYPES.LAGUERRE.value,\n",
     "                             \"poly_degree\": 3,\n",
     "                             })"
    ]

--- a/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
+++ b/notebooks/products/equity/EQUITY_VANILLA_AMERICAN_STYLE_OPTION.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:57.562888Z",
@@ -48,7 +48,7 @@
      "output_type": "stream",
      "text": [
       "####################################################################\n",
-      "# FINANCEPY BETA Version 0.270 - This build:  26 Feb 2023 at 19:12 #\n",
+      "# FINANCEPY BETA Version 0.280 - This build:  16 Apr 2023 at 11:54 #\n",
       "#      This software is distributed FREE & WITHOUT ANY WARRANTY    #\n",
       "#  Report bugs as issues at https://github.com/domokane/FinancePy  #\n",
       "####################################################################\n",
@@ -60,7 +60,8 @@
     "from financepy.utils import *\n",
     "from financepy.market.curves import *\n",
     "from financepy.products.equity import *\n",
-    "from financepy.models.black_scholes import *"
+    "from financepy.models.black_scholes import *\n",
+    "from financepy.models.equity_lsmc import FIT_TYPES"
    ]
   },
   {
@@ -72,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.733804Z",
@@ -88,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.741755Z",
@@ -104,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.748736Z",
@@ -113,14 +114,25 @@
      "shell.execute_reply": "2021-01-17T21:44:58.751728Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "01-JUL-2015"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "expiry_date"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.753750Z",
@@ -136,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.757904Z",
@@ -160,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.761865Z",
@@ -176,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.766045Z",
@@ -199,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.770033Z",
@@ -215,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.780976Z",
@@ -231,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.786959Z",
@@ -247,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.793940Z",
@@ -263,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.799956Z",
@@ -272,14 +284,26 @@
      "shell.execute_reply": "2021-01-17T21:44:58.801965Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OBJECT TYPE: EquityAmericanOption\n",
+      "EXPIRY DATE: 01-JUL-2015\n",
+      "STRIKE PRICE: 50.0\n",
+      "OPTION TYPE: OptionTypes.AMERICAN_CALL\n",
+      "NUMBER: 1.0\n"
+     ]
+    }
+   ],
    "source": [
     "print(americanCallOption)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.805909Z",
@@ -288,7 +312,19 @@
      "shell.execute_reply": "2021-01-17T21:44:58.807968Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OBJECT TYPE: EquityAmericanOption\n",
+      "EXPIRY DATE: 01-JUL-2015\n",
+      "STRIKE PRICE: 50.0\n",
+      "OPTION TYPE: OptionTypes.AMERICAN_PUT\n",
+      "NUMBER: 1.0\n"
+     ]
+    }
+   ],
    "source": [
     "print(americanPutOption)"
    ]
@@ -302,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.810931Z",
@@ -321,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.817911Z",
@@ -337,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.822898Z",
@@ -360,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.827915Z",
@@ -376,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.831874Z",
@@ -385,14 +421,25 @@
      "shell.execute_reply": "2021-01-17T21:44:58.833897Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276581469416914"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.835863Z",
@@ -401,7 +448,18 @@
      "shell.execute_reply": "2021-01-17T21:44:58.837886Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276581469416914"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -415,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,56 +488,122 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276581469416914"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276540933598305"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276540933598305"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2031750852278296"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2031710315837243"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanAmericanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.319903905249911"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -493,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,56 +632,266 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276581469416914"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.427654222018065"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276542239745815"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2031750852278296"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2031706411098173"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanAmericanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {
     "scrolled": false
    },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.319761786494424"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "americanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### LSMC Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
    "outputs": [],
+   "source": [
+    "model = BlackScholes(volatility,\n",
+    "                     num_steps_per_year=52,\n",
+    "                     num_paths=50_000,\n",
+    "                     implementationType=BlackScholesTypes.LSMC,\n",
+    "                     params={\"fit_type\": FIT_TYPES.LAGUERRE,\n",
+    "                             \"poly_degree\": 3,\n",
+    "                             })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276581469416914"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.370852795803322"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.3460269746824265"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "americanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2031750852278296"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "europeanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.1463697340894656"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "europeanAmericanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2100861602100434"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -572,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,25 +915,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4276581469416914"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.427145909428062"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanAmericanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-01-17T21:44:58.839882Z",
@@ -608,25 +964,58 @@
      "shell.execute_reply": "2021-01-17T21:44:59.029389Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.427145909428062"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanCallOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2031750852278296"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.2026628477140777"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "europeanAmericanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -640,9 +1029,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.3227588252294726"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanPutOption.value(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
@@ -670,36 +1070,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.6240485077846358"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanCallOption.delta(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "534.1064689190489"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanCallOption.gamma(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-4.0724784861637575"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanCallOption.theta(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "13.096682231981127"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "americanCallOption.rho(valuation_date, stock_price, discount_curve, dividend_curve, model)"
    ]

--- a/tests/test_lsmc.py
+++ b/tests/test_lsmc.py
@@ -1,0 +1,140 @@
+from financepy.utils.global_types import OptionTypes
+from financepy.utils.date import Date
+from financepy.utils.global_vars import gDaysInYear
+from financepy.models.equity_crr_tree import crr_tree_val_avg
+from financepy.models.equity_lsmc import equity_lsmc, FIT_TYPES
+from financepy.products.equity.equity_vanilla_option import EquityVanillaOption
+from financepy.models.black_scholes import BlackScholes
+from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
+
+from pytest import approx
+
+
+def test_american_call():
+    """
+    Check finite difference method gives similar result to binomial tree
+    """
+    spot_price = 50.0
+    strike_price = 50.0
+    risk_free_rate = 0.06
+    dividend_yield = 0.00
+    volatility = 0.40
+    valuation_date = Date(1, 1, 2016)
+    expiry_date = Date(1, 1, 2017)
+    # TODO MAKE WORK WITH EUROPEAN OPTIONS
+    option_type = OptionTypes.AMERICAN_CALL
+
+    time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
+    num_steps_per_year = 500
+    num_paths = 50_000
+    poly_degree = 15
+
+    v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+
+    value = crr_tree_val_avg(spot_price,
+                             risk_free_rate,  # continuously compounded
+                             dividend_yield,  # continuously compounded
+                             volatility,  # Black scholes volatility
+                             50, #num_steps_per_year,
+                             time_to_expiry,
+                             option_type.value,
+                             strike_price)
+    assert v_ls == approx(value['value'], abs=1e-1)
+
+
+def test_american_put():
+    """
+    Check finite difference method gives similar result to binomial tree
+    """
+    spot_price = 50.0
+    strike_price = 50.0
+    risk_free_rate = 0.06
+    dividend_yield = 0.00
+    volatility = 0.20
+    valuation_date = Date(1, 1, 2016)
+    expiry_date = Date(1, 1, 2017)
+    # TODO MAKE WORK WITH EUROPEAN OPTIONS
+    option_type = OptionTypes.AMERICAN_PUT
+
+    time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
+    num_steps_per_year = 500
+    num_paths = 50_000
+    poly_degree = 15
+
+    v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+
+    value = crr_tree_val_avg(spot_price,
+                             risk_free_rate,  # continuously compounded
+                             dividend_yield,  # continuously compounded
+                             volatility,  # Black scholes volatility
+                             50,  # num_steps_per_year,
+                             time_to_expiry,
+                             option_type.value,
+                             strike_price)
+    assert v_ls == approx(value['value'], abs=1e-1)
+
+
+def test_call_option():
+    """
+    Check finite difference method gives similar result to BlackScholes model
+    """
+    expiry_date = Date(1, 7, 2015)
+    strike_price = 100.0
+    option_type = OptionTypes.EUROPEAN_CALL
+    call_option = EquityVanillaOption(
+        expiry_date, strike_price, option_type)
+
+    valuation_date = Date(1, 1, 2015)
+    spot_price = 100
+    volatility = 0.20
+    risk_free_rate = 0.05
+    dividend_yield = 0.01
+    num_steps_per_year = 500
+    num_paths = 50_000
+    poly_degree = 15
+    model = BlackScholes(volatility)
+    time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
+    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+
+    # Call option
+    v0 = call_option.value(valuation_date, spot_price,
+                           discount_curve, dividend_curve, model)
+
+    v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+    assert v_ls == approx(v0, 1e-1)
+
+
+def test_put_option():
+    """
+    Check finite difference method gives similar result to BlackScholes model
+    """
+    expiry_date = Date(1, 7, 2015)
+    strike_price = 100.0
+    option_type = OptionTypes.EUROPEAN_PUT
+    put_option = EquityVanillaOption(
+        expiry_date, strike_price, option_type)
+
+    valuation_date = Date(1, 1, 2015)
+    spot_price = 100
+    volatility = 0.20
+    risk_free_rate = 0.05
+    dividend_yield = 0.1
+    num_steps_per_year = 500
+    num_paths = 50_000
+    poly_degree = 15
+    model = BlackScholes(volatility)
+    time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
+    discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
+    dividend_curve = DiscountCurveFlat(valuation_date, dividend_yield)
+
+    # Call option
+    v0 = put_option.value(valuation_date, spot_price,
+                          discount_curve, dividend_curve, model)
+    v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+
+    assert v_ls == approx(v0, 1e-1)

--- a/tests/test_lsmc.py
+++ b/tests/test_lsmc.py
@@ -30,7 +30,7 @@ def test_american_call():
     poly_degree = 5
 
     v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
-                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE.value, 0, 0)
 
     value = crr_tree_val_avg(spot_price,
                              risk_free_rate,  # continuously compounded
@@ -63,7 +63,7 @@ def test_american_put():
     poly_degree = 5
 
     v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
-                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE.value, 0, 0)
 
     value = crr_tree_val_avg(spot_price,
                              risk_free_rate,  # continuously compounded
@@ -104,7 +104,7 @@ def test_call_option():
                            discount_curve, dividend_curve, model)
 
     v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
-                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE.value, 0, 0)
     assert v_ls == approx(v0, 1e-1)
 
 
@@ -135,6 +135,6 @@ def test_put_option():
     v0 = put_option.value(valuation_date, spot_price,
                           discount_curve, dividend_curve, model)
     v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
-                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
+                       time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE.value, 0, 0)
 
     assert v_ls == approx(v0, 1e-1)

--- a/tests/test_lsmc.py
+++ b/tests/test_lsmc.py
@@ -27,7 +27,7 @@ def test_american_call():
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
     num_steps_per_year = 500
     num_paths = 50_000
-    poly_degree = 15
+    poly_degree = 5
 
     v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
                        time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
@@ -60,7 +60,7 @@ def test_american_put():
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
     num_steps_per_year = 500
     num_paths = 50_000
-    poly_degree = 15
+    poly_degree = 5
 
     v_ls = equity_lsmc(spot_price, risk_free_rate, dividend_yield, volatility, num_steps_per_year, num_paths,
                        time_to_expiry, option_type.value, strike_price, poly_degree, FIT_TYPES.LAGUERRE, 0, 0)
@@ -93,7 +93,7 @@ def test_call_option():
     dividend_yield = 0.01
     num_steps_per_year = 500
     num_paths = 50_000
-    poly_degree = 15
+    poly_degree = 5
     model = BlackScholes(volatility)
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
     discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)
@@ -125,7 +125,7 @@ def test_put_option():
     dividend_yield = 0.1
     num_steps_per_year = 500
     num_paths = 50_000
-    poly_degree = 15
+    poly_degree = 5
     model = BlackScholes(volatility)
     time_to_expiry = (expiry_date - valuation_date) / gDaysInYear
     discount_curve = DiscountCurveFlat(valuation_date, risk_free_rate)


### PR DESCRIPTION
Closes https://github.com/domokane/FinancePy/issues/175

This adds several different polynomial approximations to the existing LSMC model and tests the LSMC model against CRR tree. It fixes a few bugs with the model as well. 

This model is slower and less accurate than the tree and finite difference models. It can only match them for accuracy when the volatility and interest rate are both set to zero (with high volatility in particular hurting it's accuracy).  The unit tests only test accuracy  to 1e-1 and are only testing a one year expiry (unlike the analogous finite difference model tests that use 5 year expiry dates). They can get to 1e-2, or maybe 1e-3 accuracy, but it requires very high polynomial degree (>30), and many timesteps, making it prohibitively slow. 

I've also had to remove the numba jitting of equity_lsmc in order to get the other polynomial approximations in. We can maybe add this back in later.

Profiling this model shows that about half the time running this model is spent fitting the polynomial approximation. We could maybe speed things up by writing our own approximations and jitting them, but I'm not sure. The existing jitted polynomial fitting methods don't seem much faster than the numpy implementation. 

The paper this model is based on only used the in-the-money paths, whereas we use all of them. That would probably speed things up quite a lot but we would need to move from numpy/vectorised equations to loops/numba to do this.