### PR TITLE
Changed 'Date' type to float type in parameters of barrier option pricing functions.

### DIFF
--- a/financepy/models/equity_barrier_models.py
+++ b/financepy/models/equity_barrier_models.py
@@ -5,35 +5,26 @@
 import numpy as np
 
 from ..market.curves.discount_curve import DiscountCurve
-from ..utils.date import Date
 from ..utils.error import FinError
 from ..utils.global_types import EquityBarrierTypes
-from ..utils.global_vars import gDaysInYear
 from ..utils.math import N
 
 
 # Calculates the Barrier option price using an Analytical Approach
 # and the Black Scholes Model
-def value_bs(expiry_date: Date,
+def value_bs(time_to_expiry: float,  # time in years
               strike_price: float,
               option_type: int,
               barrier_level: float,
               num_observations,  # number of observations per year
               notional: float,
-              valuation_date: Date,
               stock_price: (float, np.ndarray),
               rf_rate: float,
               div_rate: float,
               model):
     """ This values a single option. Because of its structure it cannot
     easily be vectorised which is why it has been wrapped. """
-
-    t_exp = (expiry_date - valuation_date) / gDaysInYear
-
-    if t_exp < 0:
-        raise FinError("Option expires before value date.")
-
-    t_exp = max(t_exp, 1e-6)
+    t_exp = max(time_to_expiry, 1e-6)
 
     lnS0k = np.log(stock_price / strike_price)
     sqrtT = np.sqrt(t_exp)

--- a/tests/test_FinEquityBarrierOption.py
+++ b/tests/test_FinEquityBarrierOption.py
@@ -9,7 +9,7 @@ from financepy.products.equity.equity_barrier_option import EquityBarrierOption
 from financepy.products.equity.equity_barrier_option import EquityBarrierTypes
 from financepy.models.process_simulator import FinGBMNumericalScheme
 from financepy.models.process_simulator import ProcessTypes
-
+from financepy.utils.global_vars import gDaysInYear
 
 valuation_date = Date(1, 1, 2015)
 expiry_date = Date(1, 1, 2016)
@@ -47,9 +47,10 @@ def test_down_and_out_call():
         model)
 
     assert round(value, 4) == 0.0000
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional
+                                    , stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 0.0000
 
@@ -67,10 +68,10 @@ def test_down_and_in_call():
         model)
 
     assert round(value, 4) == 1.5307
-
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional,
+                                    stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 1.5718
 
@@ -88,10 +89,10 @@ def test_up_and_out_call():
         model)
 
     assert round(value, 4) == 0.1789
-
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional,
+                                    stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 0.1706
 
@@ -109,10 +110,10 @@ def test_up_and_in_call():
         model)
 
     assert round(value, 4) == 1.3519
-
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional,
+                                    stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 1.4426
 
@@ -130,10 +131,10 @@ def test_up_and_out_put():
         model)
 
     assert round(value, 4) == 18.1445
-
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional,
+                                    stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 17.8602
 
@@ -151,10 +152,10 @@ def test_up_and_in_put():
         model)
 
     assert round(value, 4) == 0.0933
-
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional,
+                                    stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 0.0940
 
@@ -172,10 +173,10 @@ def test_down_and_out_put():
         model)
 
     assert round(value, 4) == 0.0000
-
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional,
+                                    stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 0.0000
 
@@ -193,9 +194,20 @@ def test_down_and_in_put():
         model)
 
     assert round(value, 4) == 18.2378
-
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     model_params = (stock_price, drift, volatility, scheme)
-    test_value_mc = option.value_mc(expiry_date, K, option_type.value, B, notional, valuation_date, stock_price,
-                             discount_curve.cc_rate(expiry_date), process_type, model_params)
+    test_value_mc = option.value_mc(t_exp, K, option_type.value, B, notional,
+                                    stock_price, discount_curve.cc_rate(expiry_date), process_type, model_params)
 
     assert round(test_value_mc, 4) == 17.9996
+
+
+if __name__ == '__main__':
+    test_down_and_in_put()
+    test_down_and_in_call()
+    test_up_and_in_call()
+    test_up_and_in_put()
+    test_down_and_out_put()
+    test_down_and_out_call()
+    test_up_and_out_call()
+    test_up_and_out_put()

--- a/tests_golden/TestFinEquityBarrierOption.py
+++ b/tests_golden/TestFinEquityBarrierOption.py
@@ -3,6 +3,9 @@
 ###############################################################################
 
 import sys
+
+from financepy.utils import gDaysInYear
+
 sys.path.append("..")
 
 from FinTestCases import FinTestCases, globalTestCaseMode
@@ -26,6 +29,7 @@ def test_EquityBarrierOption():
 
     valuation_date = Date(1, 1, 2015)
     expiry_date = Date(1, 1, 2016)
+    t_exp = (expiry_date - valuation_date) / gDaysInYear
     stock_price = 100.0
     volatility = 0.20
     interest_rate = 0.05
@@ -79,12 +83,11 @@ def test_EquityBarrierOption():
             start = time.time()
             model_params = (stock_price, drift, volatility, scheme)
 
-            test_value_mc = option.value_mc(expiry_date, 
+            test_value_mc = option.value_mc(t_exp,
                                      K, 
                                      option_type.value, 
                                      B, 
-                                     notional, 
-                                     valuation_date, 
+                                     notional,
                                      stock_price,
                                      discount_curve.cc_rate(expiry_date), 
                                      process_type, 
@@ -120,12 +123,11 @@ def test_EquityBarrierOption():
             start = time.time()
             model_params = (stock_price, drift, volatility, scheme)
 
-            test_value_mc = option.value_mc(expiry_date, 
+            test_value_mc = option.value_mc(t_exp,
                                      K, 
                                      option_type.value, 
                                      B, 
-                                     notional, 
-                                     valuation_date, 
+                                     notional,
                                      stock_price,
                                      discount_curve.cc_rate(expiry_date), 
                                      process_type, 


### PR DESCRIPTION
Hello Sir
I added a to_float method in the Date class, to allow acess to the already existing (private) parameter _excel_date , which is a float. I'm using this method whenever we're calling the barrier options pricing functions to pass floats instead of Date. 
Let me know if this is fine,

Gautier