### PR TITLE
Fix swap leg

### DIFF
--- a/financepy/products/rates/swap_float_leg.py
+++ b/financepy/products/rates/swap_float_leg.py
@@ -269,14 +269,13 @@ class SwapFloatLeg:
         print("FREQUENCY:", str(self._freq_type))
         print("DAY COUNT:", str(self._day_count_type))
 
-        self.print_payments()
-
         if len(self._payments) == 0:
             print("Payments not calculated.")
             return
 
-        header = [ "PAY_NUM", "PAY_DATE",  "NOTIONAL", 
-                  "IBOR", "PMNT", "DF", "PV", "CUM_PV"]
+        header = [ "PAY_NUM", "PAY_DATE",  "NOTIONAL",
+                  "DAYS", "YEARFRAC", "IBOR", "PMNT", 
+                  "DF", "PV", "CUM_PV"]
 
         rows = []          
         num_flows = len(self._payment_dates)
@@ -285,6 +284,8 @@ class SwapFloatLeg:
                 iFlow + 1,
                 self._payment_dates[iFlow],
                 round(self._notional_array[iFlow], 0),
+                self._accrued_days[iFlow],
+                round(self._year_fracs[iFlow],4),
                 round(self._rates[iFlow] * 100.0, 4),
                 round(self._payments[iFlow], 2),
                 round(self._paymentDfs[iFlow], 4),

--- a/financepy/products/rates/swap_float_leg.py
+++ b/financepy/products/rates/swap_float_leg.py
@@ -274,8 +274,7 @@ class SwapFloatLeg:
             return
 
         header = [ "PAY_NUM", "PAY_DATE",  "NOTIONAL",
-                  "DAYS", "YEARFRAC", "IBOR", "PMNT", 
-                  "DF", "PV", "CUM_PV"]
+                  "IBOR", "PMNT", "DF", "PV", "CUM_PV"]
 
         rows = []          
         num_flows = len(self._payment_dates)
@@ -284,8 +283,6 @@ class SwapFloatLeg:
                 iFlow + 1,
                 self._payment_dates[iFlow],
                 round(self._notional_array[iFlow], 0),
-                self._accrued_days[iFlow],
-                round(self._year_fracs[iFlow],4),
                 round(self._rates[iFlow] * 100.0, 4),
                 round(self._payments[iFlow], 2),
                 round(self._paymentDfs[iFlow], 4),


### PR DESCRIPTION
Address self.print_valuation() concerns raised in issue #188.

Now swap.print_float_leg_pv() becomes:

![image](https://github.com/domokane/FinancePy/assets/81002528/8e25c31c-fa7a-4b00-a46c-32ff29242f67)

Which is much more in-line with swap.print_fixed_leg_pv():

![image](https://github.com/domokane/FinancePy/assets/81002528/35b9b4a4-ede0-4008-824b-3442a116d4cd)
