### PR TITLE
[codex] Add joint market calendar support

### DIFF
--- a/financepy/utils/calendar.py
+++ b/financepy/utils/calendar.py
@@ -364,12 +364,60 @@ class Calendar:
     specified calendar."""
 
     def __init__(self, cal_type: CalendarTypes):
-        """Create a calendar based on a specified calendar type."""
+        """Create a calendar based on one or more specified calendar types."""
 
-        if cal_type not in CalendarTypes:
-            raise FinError("Invalid calendar type " + str(cal_type))
+        self.cal_types = self._validate_calendar_types(cal_type)
+        self.cal_type = self.cal_types[0] if len(self.cal_types) == 1 else self.cal_types
+        self._calendars = (
+            tuple(Calendar(cal_type) for cal_type in self.cal_types)
+            if len(self.cal_types) > 1
+            else ()
+        )
 
-        self.cal_type = cal_type
+    ####################################################################################
+
+    @staticmethod
+    def _validate_calendar_types(cal_type):
+        """Validate and normalize a single or joint calendar specification."""
+
+        if isinstance(cal_type, CalendarTypes):
+            return (cal_type,)
+
+        if isinstance(cal_type, (list, tuple)):
+            if len(cal_type) == 0:
+                raise FinError("Calendar type list cannot be empty")
+
+            cal_types = []
+            for single_cal_type in cal_type:
+                if isinstance(single_cal_type, CalendarTypes) is False:
+                    raise FinError("Invalid calendar type " + str(single_cal_type))
+                if single_cal_type not in cal_types:
+                    cal_types.append(single_cal_type)
+
+            return tuple(cal_types)
+
+        raise FinError("Invalid calendar type " + str(cal_type))
+
+    ####################################################################################
+
+    def _is_single_calendar_type(self, cal_type: CalendarTypes):
+        """Return True when this calendar is exactly one calendar type."""
+
+        return len(self.cal_types) == 1 and self.cal_types[0] == cal_type
+
+    ####################################################################################
+
+    def _is_all_calendar_type(self, cal_type: CalendarTypes):
+        """Return True when every component calendar has the requested type."""
+
+        return all(single_cal_type == cal_type for single_cal_type in self.cal_types)
+
+    ####################################################################################
+
+    def _calendar_name(self):
+        """Return a display name for a single or joint calendar."""
+
+        return "+".join(cal_type.name for cal_type in self.cal_types)
 
     ####################################################################################
 
@@ -387,7 +435,7 @@ class Calendar:
             raise FinError("Invalid type passed. Need Finbd_type")
 
         # If calendar type is NONE then every day is a business day
-        if self.cal_type == CalendarTypes.NONE:
+        if self._is_all_calendar_type(CalendarTypes.NONE):
             return dt
 
         if bd_type == BusDayAdjustTypes.NONE:
@@ -461,7 +509,10 @@ class Calendar:
             raise FinError("Invalid type passed. Need BusDayAdjustTypes")
 
         # If no calendar or no adjustment, nothing to do
-        if self.cal_type == CalendarTypes.NONE or bd_type == BusDayAdjustTypes.NONE:
+        if (
+            self._is_all_calendar_type(CalendarTypes.NONE)
+            or bd_type == BusDayAdjustTypes.NONE
+        ):
             return dt
 
         # FOLLOWING convention
@@ -554,7 +605,7 @@ class Calendar:
         if num_days == 0:
             return start_dt
 
-        if self.cal_type == CalendarTypes.NONE:
+        if self._is_all_calendar_type(CalendarTypes.NONE):
             return start_dt.add_days(num_days)
 
         step = 1 if num_days > 0 else -1
@@ -562,7 +613,7 @@ class Calendar:
         dt = start_dt
 
         # Safe fast path for weekend-only calendar
-        if self.cal_type == CalendarTypes.WEEKEND:
+        if self._is_single_calendar_type(CalendarTypes.WEEKEND):
             weeks, days_left = divmod(days_left, 5)
             dt = dt.add_days(step * 7 * weeks)
 
@@ -622,8 +673,11 @@ class Calendar:
         calendar. If it is it returns True, otherwise False."""
 
         # Every day is a business day when the Calendar is NONE
-        if self.cal_type == CalendarTypes.NONE:
+        if self._is_all_calendar_type(CalendarTypes.NONE):
             return True
+
+        if self._calendars:
+            return all(calendar.is_business_day(dt) for calendar in self._calendars)
 
         # For all calendars so far, SAT and SUN are not business days
         # If this ever changes I will need to add a filter here.
@@ -641,6 +695,9 @@ class Calendar:
         """Determines if a date is a Holiday according to the specified
         calendar. Weekends are not holidays unless the holiday falls on a
         weekend date."""
+
+        if self._calendars:
+            return any(calendar.is_holiday(dt) for calendar in self._calendars)
 
         start_dt = Date(1, 1, dt.y)
         day_in_year = dt.excel_dt - start_dt.excel_dt + 1
@@ -1492,13 +1549,13 @@ class Calendar:
     ###########################################################################
 
     def __str__(self):
-        s = self.cal_type.name
+        s = self._calendar_name()
         return s
 
     ###########################################################################
 
     def __repr__(self):
-        s = self.cal_type.name
+        s = self._calendar_name()
         return s
 
 

--- a/financepy/utils/helpers.py
+++ b/financepy/utils/helpers.py
@@ -444,6 +444,8 @@ def to_usable_type(t):
         # t is a normal type
         if t is float:
             return (int, float, np.float64)
+        if getattr(t, "__name__", None) == "CalendarTypes":
+            return (t, list, tuple)
         if isinstance(t, tuple):
             return tuple(to_usable_type(tp) for tp in t)
 

--- a/unit_tests/test_FinCalendar.py
+++ b/unit_tests/test_FinCalendar.py
@@ -3,6 +3,7 @@
 from financepy.utils.calendar import Calendar, CalendarTypes
 from financepy.utils.calendar import BusDayAdjustTypes
 from financepy.utils.date import Date
+from financepy.utils.error import FinError
 
 bus_days_in_decade = {
     CalendarTypes.NONE: 3653,
@@ -39,7 +40,11 @@ MONTHS = {
 
 
 def date_from_string(s):
-    _, d, m, y = s.split()
+    parts = s.split()
+    if len(parts) == 4:
+        _, d, m, y = parts
+    else:
+        d, m, y = s.split("-")
     return Date(int(d), MONTHS[m], int(y))
 
 
@@ -216,6 +221,42 @@ def test_modified_following_does_not_cross_month():
     adjusted = cal.adjust(dt, BusDayAdjustTypes.MODIFIED_FOLLOWING)
 
     assert adjusted == Date(30, 7, 2021)
+
+
+def test_joint_calendar_uses_union_of_holidays():
+    joint = Calendar((CalendarTypes.UNITED_STATES, CalendarTypes.TARGET))
+    us = Calendar(CalendarTypes.UNITED_STATES)
+    target = Calendar(CalendarTypes.TARGET)
+
+    us_holiday = Date(4, 7, 2022)
+    target_holiday = Date(1, 5, 2024)
+
+    assert not us.is_business_day(us_holiday)
+    assert target.is_business_day(us_holiday)
+    assert not joint.is_business_day(us_holiday)
+    assert joint.is_holiday(us_holiday)
+
+    assert us.is_business_day(target_holiday)
+    assert not target.is_business_day(target_holiday)
+    assert not joint.is_business_day(target_holiday)
+    assert joint.is_holiday(target_holiday)
+
+
+def test_joint_calendar_adjusts_and_adds_business_days():
+    joint = Calendar([CalendarTypes.TARGET, CalendarTypes.UNITED_STATES])
+
+    assert joint.adjust(
+        Date(4, 7, 2022), BusDayAdjustTypes.FOLLOWING
+    ) == Date(5, 7, 2022)
+    assert joint.adjust(
+        Date(1, 5, 2024), BusDayAdjustTypes.FOLLOWING
+    ) == Date(2, 5, 2024)
+    assert joint.add_business_days(Date(1, 7, 2022), 1) == Date(5, 7, 2022)
+
+
+def test_joint_calendar_rejects_invalid_member():
+    with pytest.raises(FinError):
+        Calendar((CalendarTypes.TARGET, "UNITED_STATES"))
 
 
 @pytest.mark.parametrize("cal_type", list(CalendarTypes))

--- a/unit_tests/test_FinSchedule.py
+++ b/unit_tests/test_FinSchedule.py
@@ -101,6 +101,27 @@ def test_forward_frequencies():
 ########################################################################################
 
 
+def test_schedule_accepts_joint_calendar():
+
+    d1 = Date(4, 1, 2022)
+    d2 = Date(4, 7, 2022)
+
+    schedule = Schedule(
+        d1,
+        d2,
+        FrequencyTypes.SEMI_ANNUAL,
+        (CalendarTypes.TARGET, CalendarTypes.UNITED_STATES),
+        BusDayAdjustTypes.FOLLOWING,
+        DateGenRuleTypes.BACKWARD,
+        termination_date_adjust,
+    )
+
+    assert schedule.adjusted_dts[-1] == Date(5, 7, 2022)
+
+
+########################################################################################
+
+
 def test_backward_front_stub():
 
     # BACKWARD SHORT STUB AT FRONT


### PR DESCRIPTION
## Summary
- add support for joint market calendars by allowing `Calendar` to accept a list or tuple of `CalendarTypes`
- treat joint-calendar business days as the intersection of component business days, so any component market holiday blocks the date
- allow existing `CalendarTypes` argument checks to pass joint calendar specs through to `Calendar`
- cover US/TARGET joint calendar behavior and Schedule generation for a US holiday date

Closes #228.

## Validation
- `python -m pytest unit_tests\test_FinCalendar.py unit_tests\test_FinSchedule.py -q`
- `git diff --check`