### PR TITLE
[codex] Expose end-of-month scheduling on IborSwap

### DIFF
--- a/financepy/products/rates/ibor_swap.py
+++ b/financepy/products/rates/ibor_swap.py
@@ -55,6 +55,7 @@ class IborSwap:
         cal_type: CalendarTypes = CalendarTypes.WEEKEND,
         bd_type: BusDayAdjustTypes = BusDayAdjustTypes.FOLLOWING,
         dg_type: DateGenRuleTypes = DateGenRuleTypes.BACKWARD,
+        end_of_month: bool = False,
     ):
         """Create an interest rate swap contract giving the contract start
         date, its maturity, fixed cpn, fixed leg frequency, fixed leg day
@@ -100,6 +101,7 @@ class IborSwap:
             cal_type,
             bd_type,
             dg_type,
+            end_of_month,
         )
 
         self.float_leg = SwapFloatLeg(
@@ -115,6 +117,7 @@ class IborSwap:
             cal_type,
             bd_type,
             dg_type,
+            end_of_month,
         )
 
     ###########################################################################

--- a/unit_tests/test_FinIborSwap.py
+++ b/unit_tests/test_FinIborSwap.py
@@ -42,3 +42,53 @@ def test_ibor_swap_end_of_month_aligns_coupon_grid():
         ibor_swaps=swaps,
         interp_type=InterpTypes.FLAT_FWD_RATES,
     )
+
+
+def test_ibor_swap_end_of_month_handles_non_eom_effective_date():
+    swap = IborSwap(
+        effective_dt=Date(15, 5, 2023),
+        term_dt_or_tenor="1Y",
+        fixed_leg_type=SwapTypes.PAY,
+        fixed_cpn=0.01,
+        fixed_freq_type=FrequencyTypes.QUARTERLY,
+        fixed_dc_type=DayCountTypes.ACT_360,
+        float_dc_type=DayCountTypes.ACT_360,
+        bd_type=BusDayAdjustTypes.NONE,
+        end_of_month=True,
+    )
+
+    assert swap.fixed_leg.payment_dts == [
+        Date(31, 5, 2023),
+        Date(31, 8, 2023),
+        Date(30, 11, 2023),
+        Date(29, 2, 2024),
+        Date(15, 5, 2024),
+    ]
+
+
+def test_ibor_swap_end_of_month_applies_to_float_leg_schedule():
+    swap = IborSwap(
+        effective_dt=Date(31, 5, 2023),
+        term_dt_or_tenor="1Y",
+        fixed_leg_type=SwapTypes.PAY,
+        fixed_cpn=0.01,
+        fixed_freq_type=FrequencyTypes.ANNUAL,
+        fixed_dc_type=DayCountTypes.ACT_360,
+        float_freq_type=FrequencyTypes.QUARTERLY,
+        float_dc_type=DayCountTypes.ACT_360,
+        bd_type=BusDayAdjustTypes.NONE,
+        end_of_month=True,
+    )
+
+    assert swap.float_leg.payment_dts == [
+        Date(31, 8, 2023),
+        Date(30, 11, 2023),
+        Date(29, 2, 2024),
+        Date(31, 5, 2024),
+    ]
+    assert swap.float_leg.start_accrued_dts == [
+        Date(31, 5, 2023),
+        Date(31, 8, 2023),
+        Date(30, 11, 2023),
+        Date(29, 2, 2024),
+    ]

--- a/unit_tests/test_FinIborSwap.py
+++ b/unit_tests/test_FinIborSwap.py
@@ -1,0 +1,44 @@
+from financepy.market.curves import InterpTypes
+from financepy.products.rates.ibor_single_curve import IborSingleCurve
+from financepy.products.rates.ibor_swap import IborSwap
+from financepy.utils import (
+    BusDayAdjustTypes,
+    Date,
+    DayCountTypes,
+    FrequencyTypes,
+    SwapTypes,
+)
+
+
+def test_ibor_swap_end_of_month_aligns_coupon_grid():
+    valuation_date = Date(31, 5, 2023)
+
+    swaps = []
+    for tenor in ["6M", "1Y"]:
+        swaps.append(
+            IborSwap(
+                effective_dt=valuation_date,
+                term_dt_or_tenor=tenor,
+                fixed_leg_type=SwapTypes.PAY,
+                fixed_cpn=0.01,
+                fixed_freq_type=FrequencyTypes.QUARTERLY,
+                fixed_dc_type=DayCountTypes.ACT_360,
+                float_dc_type=DayCountTypes.ACT_360,
+                bd_type=BusDayAdjustTypes.NONE,
+                end_of_month=True,
+            )
+        )
+
+    assert swaps[0].fixed_leg.payment_dts == [
+        Date(31, 8, 2023),
+        Date(30, 11, 2023),
+    ]
+    assert swaps[1].fixed_leg.payment_dts[:2] == swaps[0].fixed_leg.payment_dts
+
+    IborSingleCurve(
+        value_dt=valuation_date,
+        ibor_deposits=[],
+        ibor_fras=[],
+        ibor_swaps=swaps,
+        interp_type=InterpTypes.FLAT_FWD_RATES,
+    )


### PR DESCRIPTION
## Summary
- expose the existing `end_of_month` schedule option on `IborSwap`
- pass the flag through to both fixed and floating swap legs
- add a regression test for the month-end 6M/1Y swap coupon grid case from #222

This keeps the existing default behavior unchanged while giving users a direct way to request EOM-aligned swap schedules when bootstrapping curves from month-end effective dates.

Closes #222.

## Validation
- `python -m pytest unit_tests\test_FinIborSwap.py -q`
- `git diff --check`