### PR TITLE
[codex] Add Black-76 support for FX vanilla options

### DIFF
--- a/financepy/products/fx/fx_vanilla_option.py
+++ b/financepy/products/fx/fx_vanilla_option.py
@@ -22,6 +22,7 @@ from ...products.fx.fx_mkt_conventions import FinFXDeltaMethod
 from ...models.equity_crr_tree import crr_tree_val_avg
 from ...models.sabr import vol_function_sabr
 from ...models.sabr import SABR
+from ...models.black import Black
 from ...models.black_scholes import BlackScholes
 
 from ...models.black_scholes_analytic import bs_value, bs_delta
@@ -297,7 +298,11 @@ class FXVanillaOption:
 
         vdf = None
 
-        if isinstance(model, BlackScholes) or isinstance(model, SABR):
+        if isinstance(model, Black):
+
+            vdf = model.value(f0t, k, t_exp, dom_df, self.opt_type)
+
+        elif isinstance(model, BlackScholes) or isinstance(model, SABR):
 
             if isinstance(model, BlackScholes):
                 volatility = model.volatility

--- a/unit_tests/test_FinFXVanillaOption.py
+++ b/unit_tests/test_FinFXVanillaOption.py
@@ -2,6 +2,7 @@
 
 from financepy.utils.global_types import OptionTypes
 from financepy.products.fx.fx_vanilla_option import FXVanillaOption
+from financepy.models.black import Black
 from financepy.models.black_scholes import BlackScholes
 from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
 from financepy.utils.day_count import DayCountTypes
@@ -9,6 +10,49 @@ from financepy.utils.calendar import CalendarTypes
 from financepy.products.rates.ibor_single_curve import IborSingleCurve
 from financepy.products.rates.ibor_deposit import IborDeposit
 from financepy.utils.date import Date
+
+########################################################################################
+
+
+def test_fin_fx_vanilla_option_black76_matches_black_scholes_forward_value():
+
+    value_dt = Date(13, 2, 2018)
+    expiry_dt = Date(13, 2, 2019)
+
+    spot_fx_rate = 1.20
+    strike_fx_rate = 1.25
+    volatility = 0.10
+
+    domestic_curve = DiscountCurveFlat(value_dt, 0.025)
+    foreign_curve = DiscountCurveFlat(value_dt, 0.030)
+
+    call_option = FXVanillaOption(
+        expiry_dt,
+        strike_fx_rate,
+        "EURUSD",
+        OptionTypes.EUROPEAN_CALL,
+        1000000.0,
+        "USD",
+    )
+
+    black_scholes_value = call_option.value(
+        value_dt,
+        spot_fx_rate,
+        domestic_curve,
+        foreign_curve,
+        BlackScholes(volatility),
+    )
+    black76_value = call_option.value(
+        value_dt,
+        spot_fx_rate,
+        domestic_curve,
+        foreign_curve,
+        Black(volatility),
+    )
+
+    assert abs(black76_value["v"] - black_scholes_value["v"]) < 1e-12
+    assert abs(black76_value["cash_dom"] - black_scholes_value["cash_dom"]) < 1e-8
+
 
 ########################################################################################
 


### PR DESCRIPTION
## Summary
- allow `FXVanillaOption.value()` to accept the existing `Black` model
- price the option on the FX forward with the domestic discount factor, leaving existing Black-Scholes/SABR paths unchanged
- add a regression test showing Black-76 and Black-Scholes agree for the zero spot-days forward case

Closes #200.

## Validation
- `python -m pytest unit_tests\test_FinFXVanillaOption.py -q`
- `git diff --check`