### PR TITLE
Add IborSingleCurve time day count regression test

### DIFF
--- a/unit_tests/legacy/test_FinIborSingleCurve.py
+++ b/unit_tests/legacy/test_FinIborSingleCurve.py
@@ -13,6 +13,7 @@ from financepy.utils.frequency import FrequencyTypes
 from financepy.utils.day_count import DayCountTypes
 from financepy.utils.date import Date
 from financepy.utils.calendar import Calendar, CalendarTypes
+from financepy.utils.helpers import times_from_dates
 
 ########################################################################################
 
@@ -400,3 +401,40 @@ def test_reprice_inputs_for_all_interp_choices(interp_type):
 
     # If no exception, we are good
     assert True
+
+
+def test_df_uses_ibor_single_curve_time_day_count():
+    """Regression test for inherited DiscountCurve.df date conversion."""
+
+    value_dt = Date(1, 1, 2024)
+    maturity_dt = Date(1, 1, 2025)
+    depo = IborDeposit(
+        value_dt,
+        maturity_dt,
+        0.05,
+        DayCountTypes.ACT_360,
+    )
+
+    curve = IborSingleCurve(
+        value_dt,
+        [depo],
+        [],
+        [],
+        InterpTypes.FLAT_FWD_RATES,
+        time_dc_type=DayCountTypes.ACT_360,
+    )
+
+    curve_df = curve.df(maturity_dt)
+    act_360_time = times_from_dates(
+        maturity_dt,
+        value_dt,
+        DayCountTypes.ACT_360,
+    )
+    act_365f_time = times_from_dates(
+        maturity_dt,
+        value_dt,
+        DayCountTypes.ACT_365F,
+    )
+
+    assert curve_df == pytest.approx(curve.df_t(act_360_time))
+    assert curve_df != pytest.approx(curve.df_t(act_365f_time))


### PR DESCRIPTION
## Summary
- add a regression test covering `IborSingleCurve.df()` date-to-time conversion
- verify an `IborSingleCurve` configured with `time_dc_type=ACT_360` uses that day count when inherited `DiscountCurve.df()` is called with dates
- compare against `ACT_365F` time conversion to catch accidental fallback to a different curve time basis

## Why
Issue #191 raised concern that inherited discount-curve date conversion could silently use a different day-count basis from the Ibor curve. The current implementation uses `self.time_dc_type`; this test locks that behavior down without changing pricing logic.

## Validation
- `python -m pytest unit_tests/legacy/test_FinIborSingleCurve.py::test_df_uses_ibor_single_curve_time_day_count -q`
- `python -m pytest unit_tests/legacy/test_FinIborSingleCurve.py -q`

Both pytest commands passed in this Windows environment. Pytest also printed a post-run `pyarrow` access-violation stack trace while still exiting with status 0; the test assertions completed successfully.