### PR TITLE
Fix PEP 701 multi-line f-strings breaking Python 3.10/3.11 import

### DIFF
--- a/financepy/products/bonds/bond.py
+++ b/financepy/products/bonds/bond.py
@@ -1235,8 +1235,7 @@ class Bond:
                     maxiter=50,
                 )
             except RuntimeError:
-                print(f"Warning: YTM calculation did not converge for price {
-                        dirty_price}")
+                print(f"Warning: YTM calculation did not converge for price {dirty_price}")
                 ytm = np.nan
 
             ytms.append(ytm)
@@ -1546,8 +1545,7 @@ class Bond:
 
                 oass.append(oas)
             except RuntimeError:
-                print(f"Warning: OAS calculation did not converge for price {
-                        dirty_price}")
+                print(f"Warning: OAS calculation did not converge for price {dirty_price}")
                 oass.append(np.nan)
 
         if len(oass) == 1:


### PR DESCRIPTION
Fixes #248

`bond.py` used a PEP 701 multi-line replacement field inside an f-string, a Python 3.12+ only feature, which is a hard SyntaxError on 3.10/3.11 even though pyproject.toml declares requires-python = ">=3.10,<3.14". This breaks financepy.products.bonds and everything importing it transitively.

This applies fix option 1 from the issue (keep the replacement field on one line, so 3.10/3.11 stays supported) rather than bumping the minimum Python version.

While verifying the fix, found a second instance of the exact same pattern at line ~1548 (OAS-calculation warning) that wasn't mentioned in the issue, and fixed that too.

## Testing

Package imports and compiles cleanly on Python 3.11. `unit_tests/test_FinBond.py` (8 tests) and the full bond-related suite (61 tests) pass.