### PR TITLE
fix: correct swaption pay/receive value mapping

### DIFF
--- a/financepy/models/hw_tree.py
+++ b/financepy/models/hw_tree.py
@@ -1076,8 +1076,8 @@ class HWTree:
 
         # payer swaption   -> put on coupon bond
         # receiver swaption -> call on coupon bond
-        # payer, receiver
-        return (put_value, call_value)
+        # receiver, payer
+        return (call_value, put_value)
 
     ####################################################################################
 

--- a/financepy/products/rates/ibor_swaption.py
+++ b/financepy/products/rates/ibor_swaption.py
@@ -219,9 +219,9 @@ class IborSwaption:
             )
 
             if self.fixed_leg_type == SwapTypes.PAY:
-                swaption_price = swaption_px[0]
-            elif self.fixed_leg_type == SwapTypes.RECEIVE:
                 swaption_price = swaption_px[1]
+            elif self.fixed_leg_type == SwapTypes.RECEIVE:
+                swaption_price = swaption_px[0]
             else:
                 raise FinError("Unknown swaption option type" + str(self.swap_type))
 


### PR DESCRIPTION
fix the swapped return value order in HWTree and adjust the swaption pricing logic to match the corrected mapping.

- hw_tree.py:1080 — european_bond_option_jamshidian now returns (call_value, put_value), consistent with option_on_zcb, european_bond_option_expiry_only, option_on_zero_cpn_bond_tree, and bond_option()'s unpacking (hw_tree.py:1303).
- ibor_swaption.py:221 — the one caller written against the old (put, call) order now indexes [1] for PAY (put) and [0] for RECEIVE (call).